### PR TITLE
Improving authentication mechanism with better logging. Fixes #9

### DIFF
--- a/src/dynatrace-clients.ts
+++ b/src/dynatrace-clients.ts
@@ -15,6 +15,9 @@ const requestToken = async (clientId: string, clientSecret: string, authUrl: str
       scope: scopes.join(' '),
     }),
   });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch token: ${res.status} ${res.statusText}`);
+  }
   return await res.json();
 }
 

--- a/src/dynatrace-clients.ts
+++ b/src/dynatrace-clients.ts
@@ -1,23 +1,52 @@
 import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
 import { getSSOUrl } from 'dt-app';
 
+/** Uses the provided oauth Client ID and Secret and requests a token */
+const requestToken = async (clientId: string, clientSecret: string, authUrl: string, scopes: string[]): Promise<any> => {
+  const res = await fetch(authUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+      scope: scopes.join(' '),
+    }),
+  });
+  return await res.json();
+}
+
 /** Create an Oauth Client based on clientId, clientSecret, environmentUrl and scopes */
 export const createOAuthClient = async (clientId: string, clientSecret: string, environmentUrl: string, scopes: string[]): Promise<_OAuthHttpClient> => {
-  const baseUrl = await getSSOUrl(environmentUrl);
-
   if (!clientId) {
     throw new Error('Failed to retrieve OAuth client id from env "DT_APP_OAUTH_CLIENT_ID"');
   }
   if (!clientSecret) {
     throw new Error('Failed to retrieve OAuth client secret from env "DT_APP_OAUTH_CLIENT_SECRET"');
   }
-  console.error(`baseUrl=${baseUrl}`);
+  if (!environmentUrl) {
+    throw new Error('Failed to retrieve environment URL from env "DT_ENVIRONMENT"');
+  }
+
+  const ssoBaseUrl = await getSSOUrl(environmentUrl);
+  const ssoAuthUrl = new URL('/sso/oauth2/token', ssoBaseUrl).toString();
+  console.error(`Using SSO auth URL: ${ssoAuthUrl}`);
+
+  // try to request a token, just to verify that everything is set up correctly
+  const tokenResponse = await requestToken(clientId, clientSecret, ssoAuthUrl, scopes);
+  if (tokenResponse.error && tokenResponse.error_description) {
+    throw new Error(`Failed to retrieve OAuth token: ${tokenResponse.error} - ${tokenResponse.error_description}`);
+  }
+  console.error(`Successfully retrieved token from SSO!`);
+
   return new _OAuthHttpClient({
     scopes,
     clientId,
     secret: clientSecret,
     environmentUrl,
-    authUrl: new URL('/sso/oauth2/token', baseUrl).toString(),
+    authUrl: ssoAuthUrl,
   });
 };
 


### PR DESCRIPTION
Trying to fix #9 with this PR.

Idea: Add an additional check whether the oauth client ID and secret can be used to authenticate against the Dynatrace SSO.

Example output when successful:
```
2025-05-08 09:51:42.940 [warning] [server stderr] Using SSO auth URL: https://sso.dynatrace.com/sso/oauth2/token
2025-05-08 09:51:43.068 [warning] [server stderr] Successfully retrieved token from SSO!
2025-05-08 09:51:43.069 [warning] [server stderr] Starting Dynatrace MCP Server...
2025-05-08 09:51:43.077 [warning] [server stderr] Connecting server to transport...
2025-05-08 09:51:43.078 [warning] [server stderr] Dynatrace MCP Server running on stdio
```

Example output when using an invalid oauth client:
```
2025-05-08 09:52:38.077 [warning] [server stderr] Using SSO auth URL: https://sso.dynatrace.com/sso/oauth2/token
2025-05-08 09:52:38.236 [warning] [server stderr] Fatal error in main(): Error: Failed to retrieve OAuth token: invalid_request - Invalid OAuth2 request. UNSUCCESSFUL_OAUTH_ACCESS_TOKEN_VALIDATION_FAILED | ClientId or clientSecret is not correct.
2025-05-08 09:52:38.236 [warning] [server stderr]     at createOAuthClient (/home/ckreuzberger/projects/dynatrace-mcp/dist/dynatrace-clients.js:39:15)
2025-05-08 09:52:38.236 [warning] [server stderr]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-05-08 09:52:38.236 [warning] [server stderr]     at async main (/home/ckreuzberger/projects/dynatrace-mcp/dist/index.js:66:22)
```

Example output when missing a scope:
```
2025-05-08 09:53:37.353 [warning] [server stderr] Using SSO auth URL: https://sso.dynatrace.com/sso/oauth2/token
2025-05-08 09:53:37.503 [warning] [server stderr] Fatal error in main(): Error: Failed to retrieve OAuth token: invalid_request - Invalid OAuth2 request. UNSUCCESSFUL_OAUTH_ACCESS_TOKEN_VALIDATION_FAILED | OAuth client is missing following scopes [app-settings:objects:read]
2025-05-08 09:53:37.504 [warning] [server stderr]     at createOAuthClient (/home/ckreuzberger/projects/dynatrace-mcp/dist/dynatrace-clients.js:39:15)
2025-05-08 09:53:37.504 [warning] [server stderr]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-05-08 09:53:37.504 [warning] [server stderr]     at async main (/home/ckreuzberger/projects/dynatrace-mcp/dist/index.js:66:22)
```