### PR TITLE
Fix reporting of oauth issues like missing scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-automation": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [
     "Dynatrace",

--- a/src/dynatrace-clients.ts
+++ b/src/dynatrace-clients.ts
@@ -16,7 +16,7 @@ const requestToken = async (clientId: string, clientSecret: string, authUrl: str
     }),
   });
   if (!res.ok) {
-    throw new Error(`Failed to fetch token: ${res.status} ${res.statusText}`);
+    console.error(`Failed to fetch token: ${res.status} ${res.statusText}`);
   }
   return await res.json();
 }


### PR DESCRIPTION
We need to not throw an exception here, as the detail `response` (processed afterwards, hence we can not throw an Exception) of the oauth call contains concrete error messages, like
```
Error: Failed to retrieve OAuth token: invalid_request - Invalid OAuth2 request. UNSUCCESSFUL_OAUTH_ACCESS_TOKEN_VALIDATION_FAILED | OAuth client is missing following scopes [settings:objects:read]
```