### PR TITLE
feat: log MCP server version on startup and use dynamic version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,6 @@ import { DynatraceEnv, getDynatraceEnv } from "./getDynatraceEnv";
 
 config();
 
-// Get version from package.json
-
 let scopes = [
   'app-engine:apps:run', // needed for environmentInformationClient
   'app-engine:functions:run', // needed for environmentInformationClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { config } from 'dotenv';
 import { z, ZodRawShape, ZodTypeAny } from "zod";
 
+import { version as VERSION } from '../package.json';
 import { createOAuthClient } from "./dynatrace-clients";
 import { listVulnerabilities } from "./capabilities/list-vulnerabilities";
 import { listProblems } from "./capabilities/list-problems";
@@ -34,8 +35,6 @@ import { DynatraceEnv, getDynatraceEnv } from "./getDynatraceEnv";
 config();
 
 // Get version from package.json
-const packageJson = require("../package.json");
-const VERSION = packageJson.version;
 
 let scopes = [
   'app-engine:apps:run', // needed for environmentInformationClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ import { DynatraceEnv, getDynatraceEnv } from "./getDynatraceEnv";
 
 config();
 
+// Get version from package.json
+const packageJson = require("../package.json");
+const VERSION = packageJson.version;
+
 let scopes = [
   'app-engine:apps:run', // needed for environmentInformationClient
   'app-engine:functions:run', // needed for environmentInformationClient
@@ -84,11 +88,11 @@ const main = async () => {
   // create an oauth-client
   const dtClient = await createOAuthClient(oauthClient, oauthClientSecret, dtEnvironment, scopes);
 
-  console.error("Starting Dynatrace MCP Server...");
+  console.error(`Starting Dynatrace MCP Server v${VERSION}...`);
   const server = new McpServer(
     {
       name: "Dynatrace MCP Server",
-      version: "0.0.1", // ToDo: Read from package.json / hard-code?
+      version: VERSION,
     },
     {
       capabilities: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "module": "CommonJS",
     "outDir": "./dist",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

This PR addresses issue #46 by implementing version logging on server startup and using the dynamic version from package.json.

![image](https://github.com/user-attachments/assets/8e36cb1e-201c-4e78-a4b5-43453b317a6c)


## Changes Made

1. **Added version reading from package.json**: Uses `import` to import the package.json and extract the VERSION
2. **Log server version on startup**: Added `console.error(\`Starting Dynatrace MCP Server v\${VERSION}...\`)` for better troubleshooting
3. **Use dynamic version in McpServer constructor**: Replaced hardcoded '0.0.1' with the dynamic `VERSION` variable
4. **Removed TODO comment**: Cleaned up the TODO about reading version from package.json

## Technical Details

- Uses `console.error` for logging to maintain consistency with the existing codebase and avoid interfering with STDIO
- Version is loaded once at startup for efficiency
- No breaking changes to the API or functionality

## Testing

- ✅ Code compiles successfully with TypeScript
- ✅ Version is correctly read from package.json (currently 0.2.0)
- ✅ Maintains consistency with existing logging patterns

Fixes #46