### PR TITLE
chore: Added a release-workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Use Node.js # will read version from .nvmrc
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
-    # install packages
+
     - name: Install dependencies
       run: npm ci
-    # run tests
+
     - name: Test
       run: npm run test
-    # build the package
+
     - name: Build
       run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write  # Required for creating releases
-  packages: write  # Required for publishing packages
 
 jobs:
   release:
@@ -18,11 +17,10 @@ jobs:
         with:
           fetch-depth: 0  # Fetch full history for changelog generation
 
-      - name: Use Node.js
+      - name: Use Node.js # will read version from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -41,19 +39,19 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Generate changelog
+      - name: Generate changelog for GitHub Release
         id: changelog
         run: |
           # Get the previous tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
+
           # Generate changelog between tags
           if [ -n "$PREV_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD)
           else
             CHANGELOG=$(git log --pretty=format:"- %s (%h)")
           fi
-          
+
           # Save changelog to output (handle multiline)
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -66,16 +64,16 @@ jobs:
           # Create release body
           cat > release_body.md << 'EOF'
           ## Changes in ${{ steps.version.outputs.tag }}
-          
+
           ${{ steps.changelog.outputs.changelog }}
-          
+
           ## Installation
-          
+
           ```bash
           npm install @dynatrace-oss/dynatrace-mcp-server@${{ steps.version.outputs.version }}
           ```
           EOF
-          
+
           # Create the release
           if [[ "${{ steps.version.outputs.version }}" == *"-"* ]]; then
             gh release create "${{ steps.version.outputs.tag }}" \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,13 @@
 # Release Process
 
-This repository uses automated GitHub workflows to create releases whenever a new tag is pushed.
+This repository uses automated GitHub workflows to prepare releases whenever a new tag is pushed.
 
 ## How it works
 
 1. When you push a tag starting with `v` (e.g., `v1.0.0`, `v2.1.3`), the release workflow automatically triggers
 2. The workflow builds the project, runs tests, and creates a GitHub release with auto-generated release notes
+
+**Note**: This workflow does (not yet) publish the release to npmjs.com.
 
 ## Creating a Release
 
@@ -21,8 +23,8 @@ npm test
 npm run build
 
 # Create and push a tag
-git tag v1.0.0  # Replace with your desired version
-git push origin v1.0.0
+git tag vx.y.z  # Replace with your desired version
+git push origin vx.y.z
 ```
 
 After pushing the tag, the workflow will automatically:
@@ -37,40 +39,15 @@ For beta or alpha releases:
 
 ```bash
 # Create a pre-release tag
-git tag v1.0.0-beta.1
-git push origin v1.0.0-beta.1
+git tag vx.y.z-beta.1
+git push origin vx.y.z-beta.1
 ```
 
 Pre-releases will be automatically marked as such in the GitHub release.
 
 ## Release Notes
 
-The workflow automatically generates release notes by collecting all commit messages between the current and previous tag. The release notes include:
+The workflow automatically generates technical release notes by collecting all commit messages between the current and previous tag. The release notes include:
 
 - A list of changes with commit hashes
 - Proper pre-release marking for beta/alpha versions
-
-## Troubleshooting
-
-### Release workflow fails
-
-1. Check that all tests pass locally: `npm test`
-2. Verify the build works: `npm run build`
-3. Ensure the tag follows the `v*` pattern (e.g., `v1.0.0`)
-4. Check the GitHub Actions logs for specific error details
-
-### Version conflicts
-
-If you need to re-release a version:
-
-```bash
-# Delete the local tag
-git tag -d v1.0.0
-
-# Delete the remote tag
-git push origin --delete v1.0.0
-
-# Create the tag again with the correct version
-git tag v1.0.0
-git push origin v1.0.0
-```


### PR DESCRIPTION
## 🚀 Add Automated GitHub Release Workflow
Summary
This PR introduces an automated release workflow that creates GitHub releases whenever a new version tag is pushed to the repository.


### 🔧 What This Workflow Does
When you push a tag starting with v (e.g., v1.0.0, v2.1.3) it runs the test-suite, build, and publishes a GitHub Release eventually

We did not include `npm publish` as we don't have the token setup on GitHub yet.
