### PR TITLE
chore: Fix tsconfig.json to include package.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,13 @@
     "target": "ESNext",
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "rootDir": "./src",
     "moduleResolution": "node",
     "strict": true,
     "module": "CommonJS",
     "outDir": "./dist",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "package.json",],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
With https://github.com/dynatrace-oss/dynatrace-mcp/pull/47 and `resolveJsonModule` we accidentally changed the output structure (in the `dist/` folder).

Fixing tsconfig to keep the structure the same.

**how to verify**

```
rm -rf dist/
npm run build
```
should look like this:
![image](https://github.com/user-attachments/assets/cb2e1cd0-19fd-4400-818f-4553f1b59c67)
