### PR TITLE
fix: Added missing scope storage:security.events:read to executeDql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @dynatrace-oss/dynatrace-mcp-server
 
+## unreleased
+
+- Improve Authentication - fine-grained OAuth calls per tool
+- Fixed: Missing scope `storage:security.events:read` for execute DQL
+
 ## 0.3.0
 
 - Provide version of dynatrace-mcp-server on startup

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,6 +413,7 @@ const main = async () => {
           'storage:system:read', // Read System Data from Grail
           'storage:user.events:read', // Read User events from Grail
           'storage:user.sessions:read', // Read User sessions from Grail
+          'storage:security.events:read', // Read Security events from Grail
         ),
       );
       const response = await executeDql(dtClient, dqlStatement);


### PR DESCRIPTION
When querying [security events](https://docs.dynatrace.com/docs/discover-dynatrace/references/semantic-dictionary/model/security-events) we are getting an insufficient permission error:
<img width="1301" height="450" alt="image" src="https://github.com/user-attachments/assets/10394d0c-b062-4c99-8efe-fd3a2c82d9bd" />
Though the scope is added to the oauth client.

After a quick investigation I found that we are not requesting the scope.