### PR TITLE
chore: Added Dockerfile for the MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# ignore dist folder
+dist/
+# ignore node_modules
+node_modules/

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,22 @@
+name: Container
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: dynatrace-mcp:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22.17.1-alpine3.21 AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy the source code
+COPY . .
+
+# Install dependencies
+RUN npm ci
+
+# Build the application
+RUN npm run build
+
+# RUNTIME STAGE
+FROM node:22.17.1-alpine3.21
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files and install production dependencies
+COPY --from=build /app/package.json /app/package-lock.json /app/
+RUN npm ci --only=production --ignore-scripts && npm cache clean --force
+
+# Copy the built application
+COPY --from=build /app/dist /app/dist
+
+# Start the application
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Added a Dockerfile for the MCP server, as well as build jobs. While we are not yet offering a container, we are planning to do so via the [Docker MCP Hub](https://hub.docker.com/u/mcp). In order for this to work, we need to provide a Dockerfile.

To build it:
```bash
docker build . -t dynatrace-mcp
```

You can test this locally, with the following `mcp.json`:

```json
{
  "servers": {
    "dynatrace-docker-mcp-server": {
      "command": "docker",
      "cwd": "${workspaceFolder}",
      "args": [
        "run",
        "--rm",
        "-i",
        "--env-file",
        "${workspaceFolder}/.env",
        "dynatrace-mcp"
      ],
      "envFile": "${workspaceFolder}/.env"
    }
  }
}

```