### PR TITLE
feat: Added support for Platform Tokens. Fixes #40.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @dynatrace-oss/dynatrace-mcp-server
 
+## Unreleased changes
+
+- Added support for Authorization via Platform Tokens via environment variable `DT_PLATFORM_TOKENS`
+
 ## 0.4.0
 
 - Improve Authentication - fine-grained OAuth calls per tool

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Bring real-time observability data directly into your development workflow.
 
 ## Quickstart
 
-**Work in progress**
-
 You can add this MCP server (using STDIO) to your MCP Client like VS Code, Claude, Cursor, Amazon Q Developer CLI, Windsurf Github Copilot via the package `@dynatrace-oss/dynatrace-mcp-server`.
 
 We recommend to always set it up for your current workspace instead of using it globally.
@@ -106,40 +104,49 @@ This configuration should be stored in `<your-repo>/.amazonq/mcp.json`.
 
 ## Environment Variables
 
-A **Dynatrace OAuth Client** is needed to communicate with your Dynatrace Environment. Please follow the documentation about
-[creating an Oauth Client in Dynatrace](https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/oauth-clients),
-and set up the following environment variables in order for this MCP to work:
+You can set up authentication via **OAuth Client** or **Platform Tokens** via the following environment variables:
 
 - `DT_ENVIRONMENT` (string, e.g., https://abc12345.apps.dynatrace.com) - URL to your Dynatrace Platform (do not use Dynatrace classic URLs like `abc12345.live.dynatrace.com`)
 - `OAUTH_CLIENT_ID` (string, e.g., `dt0s02.SAMPLE`) - Dynatrace OAuth Client ID
 - `OAUTH_CLIENT_SECRET` (string, e.g., `dt0s02.SAMPLE.abcd1234`) - Dynatrace OAuth Client Secret
-- OAuth Client Scopes:
-  - `app-engine:apps:run` - needed for environmentInformationClient
-  - `app-engine:functions:run` - needed for environmentInformationClient
-  - `hub:catalog:read` - get details about installed Apps on Dynatrace Environment
-  - `environment-api:security-problems:read` - needed for reading security problems
-  - `environment-api:entities:read` - read monitored entities
-  - `environment-api:problems:read` - get problems
-  - `environment-api:metrics:read` - read metrics
-  - `environment-api:slo:read` - read SLOs
-  - `storage:buckets:read` - Read all system data stored on Grail
-  - `storage:logs:read` - Read logs for reliability guardian validations
-  - `storage:metrics:read` - Read metrics for reliability guardian validations
-  - `storage:bizevents:read` - Read bizevents for reliability guardian validations
-  - `storage:spans:read` - Read spans from Grail
-  - `storage:entities:read` - Read Entities from Grail
-  - `storage:events:read` - Read Events from Grail
-  - `storage:security.events:read`- Read Security Events from Grail
-  - `storage:system:read` - Read System Data from Grail
-  - `storage:user.events:read` - Read User events from Grail
-  - `storage:user.sessions:read` - Read User sessions from Grail
-  - `settings:objects:read` - needed for reading ownership information and Guardians (SRG) from settings
+- `DT_PLATFORM_TOKEN` (string, e.g., `dt0s16.SAMPLE.abcd1234`) - Dynatrace Platform Token (limited support as not all scopes are available)
 
-    **Note**: Please ensure that `settings:objects:read` is used, and _not_ the similarly named scope `app-settings:objects:read`.
+For more information, please have a look at the documentation about
+[creating an Oauth Client in Dynatrace](https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/oauth-clients), as well as
+[creating a Platform Token in Dynatrace](https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/platform-tokens).
 
 In addition, depending on the features you use, the following variables can be configured:
 
 - `SLACK_CONNECTION_ID` (string) - connection ID of a [Slack Connection](https://docs.dynatrace.com/docs/analyze-explore-automate/workflows/actions/slack)
+
+### Scopes for Authentication
+
+Depending on the features you are using, the following scopes are needed:
+
+- `app-engine:apps:run` - needed for almost all tools
+- `app-engine:functions:run` - needed for for almost all tools
+- `environment-api:security-problems:read` - needed for reading security problems (currently not available for Platform Tokens)
+- `environment-api:entities:read` - read monitored entities (currently not available for Platform Tokens)
+- `environment-api:problems:read` - get problems (currently not available for Platform Tokens)
+- `environment-api:metrics:read` - read metrics (currently not available for Platform Tokens)
+- `environment-api:slo:read` - read SLOs (currently not available for Platform Tokens)
+- `automation:workflows:read` - read Workflows
+- `automation:workflows:write` - create and update Workflows
+- `automation:workflows:run` - run Workflows
+- `storage:buckets:read` - needed for `execute_dql` tool to read all system data stored on Grail
+- `storage:logs:read` - needed for `execute_dql` tool to read logs for reliability guardian validations
+- `storage:metrics:read` - needed for `execute_dql` tool to read metrics for reliability guardian validations
+- `storage:bizevents:read` - needed for `execute_dql` tool to read bizevents for reliability guardian validations
+- `storage:spans:read` - needed for `execute_dql` tool to read spans from Grail
+- `storage:entities:read` - needed for `execute_dql` tool to read Entities from Grail
+- `storage:events:read` - needed for `execute_dql` tool to read Events from Grail
+- `storage:security.events:read`- needed for `execute_dql` tool to read Security Events from Grail
+- `storage:system:read` - needed for `execute_dql` tool to read System Data from Grail
+- `storage:user.events:read` - needed for `execute_dql` tool to read User events from Grail
+- `storage:user.sessions:read` - needed for `execute_dql` tool to read User sessions from Grail
+- `settings:objects:read` - needed for reading ownership information and Guardians (SRG) from settings
+
+  **Note**: Please ensure that `settings:objects:read` is used, and _not_ the similarly named scope `app-settings:objects:read`.
 
 ## ✨ Example prompts ✨
 

--- a/src/authentication/dynatrace-clients.test.ts
+++ b/src/authentication/dynatrace-clients.test.ts
@@ -1,0 +1,252 @@
+import { createDtHttpClient } from './dynatrace-clients';
+import { PlatformHttpClient } from '@dynatrace-sdk/http-client';
+import { getSSOUrl } from 'dt-app';
+import { OAuthTokenResponse } from './types';
+
+// Mock external dependencies
+jest.mock('@dynatrace-sdk/http-client');
+jest.mock('dt-app');
+jest.mock('../../package.json', () => ({
+  version: '1.0.0-test',
+}));
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+const mockPlatformHttpClient = PlatformHttpClient as jest.MockedClass<typeof PlatformHttpClient>;
+const mockGetSSOUrl = getSSOUrl as jest.MockedFunction<typeof getSSOUrl>;
+const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+describe('dynatrace-clients', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset console.error mock
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createDtHttpClient', () => {
+    const environmentUrl = 'https://test123.apps.dynatrace.com';
+    const scopes = ['scope1', 'scope2'];
+
+    describe('with OAuth credentials', () => {
+      const clientId = 'test-client-id';
+      const clientSecret = 'test-client-secret';
+      const platformToken = 'test-platform-token';
+
+      beforeEach(() => {
+        mockGetSSOUrl.mockResolvedValue('https://sso.dynatrace.com');
+      });
+
+      it('should create OAuth client successfully', async () => {
+        const mockTokenResponse: OAuthTokenResponse = {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'scope1 scope2',
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockTokenResponse,
+        } as Response);
+
+        const result = await createDtHttpClient(environmentUrl, scopes, clientId, clientSecret);
+
+        expect(mockGetSSOUrl).toHaveBeenCalledWith(environmentUrl);
+        expect(mockFetch).toHaveBeenCalledWith('https://sso.dynatrace.com/sso/oauth2/token', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: clientId,
+            client_secret: clientSecret,
+            scope: scopes.join(' '),
+          }),
+        });
+        expect(mockPlatformHttpClient).toHaveBeenCalledWith({
+          baseUrl: environmentUrl,
+          defaultHeaders: {
+            'Authorization': 'Bearer test-access-token',
+            'User-Agent': 'dynatrace-mcp-server/v1.0.0-test (linux-x64)',
+          },
+        });
+        expect(result).toBeInstanceOf(PlatformHttpClient);
+      });
+
+      it('should throw error when clientId, clientSecret and platformToken are missing', async () => {
+        await expect(createDtHttpClient(environmentUrl, scopes, undefined, undefined, undefined)).rejects.toThrow(
+          'Failed to create Dynatrace HTTP Client: Please provide either clientId and clientSecret or dtPlatformToken',
+        );
+      });
+
+      it('should throw error when environmentUrl is missing', async () => {
+        await expect(createDtHttpClient('', scopes, clientId, clientSecret)).rejects.toThrow(
+          'Failed to retrieve environment URL from env "DT_ENVIRONMENT"',
+        );
+      });
+
+      it('should throw error when token request fails with HTTP error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: async () => ({
+            error: 'invalid_client',
+            error_description: 'Invalid client credentials',
+          }),
+        } as Response);
+
+        await expect(createDtHttpClient(environmentUrl, scopes, clientId, clientSecret)).rejects.toThrow(
+          'Failed to retrieve OAuth token',
+        );
+
+        expect(console.error).toHaveBeenCalledWith('Failed to fetch token: 401 Unauthorized');
+      });
+
+      it('should throw error when token response contains error', async () => {
+        const mockErrorResponse: OAuthTokenResponse = {
+          error: 'invalid_scope',
+          error_description: 'The requested scope is invalid',
+          issueId: 'issue-123',
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockErrorResponse,
+        } as Response);
+
+        await expect(createDtHttpClient(environmentUrl, scopes, clientId, clientSecret)).rejects.toThrow(
+          'Failed to retrieve OAuth token (IssueId: issue-123): invalid_scope - The requested scope is invalid',
+        );
+      });
+
+      it('should throw error when token response is missing access_token', async () => {
+        const mockIncompleteResponse: OAuthTokenResponse = {
+          token_type: 'Bearer',
+          expires_in: 3600,
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockIncompleteResponse,
+        } as Response);
+
+        await expect(createDtHttpClient(environmentUrl, scopes, clientId, clientSecret)).rejects.toThrow(
+          'Failed to retrieve OAuth token',
+        );
+      });
+
+      it('should log authentication details', async () => {
+        const mockTokenResponse: OAuthTokenResponse = {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockTokenResponse,
+        } as Response);
+
+        await createDtHttpClient(environmentUrl, scopes, clientId, clientSecret);
+
+        expect(console.error).toHaveBeenCalledWith(
+          `Trying to authenticate API Calls to ${environmentUrl} via OAuthClientId ${clientId} with the following scopes: ${scopes.join(', ')}`,
+        );
+      });
+    });
+
+    describe('with Bearer token', () => {
+      const dtPlatformToken = 'test-platform-token';
+
+      it('should create Bearer token client successfully', async () => {
+        const result = await createDtHttpClient(environmentUrl, scopes, undefined, undefined, dtPlatformToken);
+
+        expect(mockPlatformHttpClient).toHaveBeenCalledWith({
+          baseUrl: environmentUrl,
+          defaultHeaders: {
+            'Authorization': `Bearer ${dtPlatformToken}`,
+            'User-Agent': 'dynatrace-mcp-server/v1.0.0-test (linux-x64)',
+          },
+        });
+        expect(result).toBeInstanceOf(PlatformHttpClient);
+      });
+    });
+
+    describe('with no authentication', () => {
+      it('should throw error when no authentication method is provided', async () => {
+        await expect(createDtHttpClient(environmentUrl, scopes)).rejects.toThrow(
+          'Failed to create Dynatrace HTTP Client: Please provide either clientId and clientSecret or dtPlatformToken',
+        );
+      });
+    });
+  });
+
+  describe('requestToken function (indirectly tested)', () => {
+    it('should handle fetch errors gracefully', async () => {
+      mockGetSSOUrl.mockResolvedValue('https://sso.dynatrace.com');
+
+      // Mock fetch to throw an error
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(
+        createDtHttpClient('https://test.apps.dynatrace.com', ['scope1'], 'client-id', 'client-secret'),
+      ).rejects.toThrow('Network error');
+    });
+
+    it('should format request body correctly', async () => {
+      mockGetSSOUrl.mockResolvedValue('https://sso.dynatrace.com');
+
+      const mockTokenResponse: OAuthTokenResponse = {
+        access_token: 'test-token',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTokenResponse,
+      } as Response);
+
+      await createDtHttpClient('https://test.apps.dynatrace.com', ['scope1', 'scope2'], 'test-client', 'test-secret');
+
+      const expectedBody = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: 'test-client',
+        client_secret: 'test-secret',
+        scope: 'scope1 scope2',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: expectedBody,
+        }),
+      );
+    });
+  });
+
+  describe('User-Agent header', () => {
+    it('should include correct User-Agent format', async () => {
+      const dtPlatformToken = 'test-token';
+
+      await createDtHttpClient('https://test.apps.dynatrace.com', ['scope1'], undefined, undefined, dtPlatformToken);
+
+      expect(mockPlatformHttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultHeaders: expect.objectContaining({
+            'User-Agent': expect.stringMatching(/^dynatrace-mcp-server\/v\d+\.\d+\.\d+(-\w+)? \(\w+-\w+\)$/),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/capabilities/call-app-function.ts
+++ b/src/capabilities/call-app-function.ts
@@ -1,12 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 
 /** Helper function to call an app-function via platform-api */
-export const callAppFunction = async (
-  dtClient: _OAuthHttpClient,
-  appId: string,
-  functionName: string,
-  payload: any,
-) => {
+export const callAppFunction = async (dtClient: HttpClient, appId: string, functionName: string, payload: any) => {
   console.error(`Sending payload ${JSON.stringify(payload)}`);
 
   const response = await dtClient.send({

--- a/src/capabilities/create-workflow-for-problem-notification.ts
+++ b/src/capabilities/create-workflow-for-problem-notification.ts
@@ -1,10 +1,8 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
-import { MonitoredEntitiesClient } from '@dynatrace-sdk/client-classic-environment-v2';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { EventTriggerConfig, WorkflowCreate, WorkflowsClient } from '@dynatrace-sdk/client-automation';
-import { randomUUID } from 'crypto';
 
 export const createWorkflowForProblemNotification = async (
-  dtClient: _OAuthHttpClient,
+  dtClient: HttpClient,
   teamName: string,
   channel: string,
   problemType: string,

--- a/src/capabilities/execute-dql.ts
+++ b/src/capabilities/execute-dql.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { QueryExecutionClient, QueryAssistanceClient, QueryResult } from '@dynatrace-sdk/client-query';
 
-export const verifyDqlStatement = async (dtClient: _OAuthHttpClient, dqlStatement: string) => {
+export const verifyDqlStatement = async (dtClient: HttpClient, dqlStatement: string) => {
   const queryAssistanceClient = new QueryAssistanceClient(dtClient);
 
   const response = await queryAssistanceClient.queryVerify({
@@ -14,7 +14,7 @@ export const verifyDqlStatement = async (dtClient: _OAuthHttpClient, dqlStatemen
 };
 
 export const executeDql = async (
-  dtClient: _OAuthHttpClient,
+  dtClient: HttpClient,
   dqlStatement: string,
 ): Promise<QueryResult['records'] | undefined> => {
   const queryExecutionClient = new QueryExecutionClient(dtClient);

--- a/src/capabilities/find-monitored-entity-by-name.ts
+++ b/src/capabilities/find-monitored-entity-by-name.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { executeDql } from './execute-dql';
 
-export const findMonitoredEntityByName = async (dtClient: _OAuthHttpClient, entityName: string) => {
+export const findMonitoredEntityByName = async (dtClient: HttpClient, entityName: string) => {
   const dql = `fetch dt.entity.application | search "*${entityName}*" | fieldsAdd entity.type
                 | append [fetch dt.entity.service | search "*${entityName}*" | fieldsAdd entity.type]
                 | append [fetch dt.entity.host | search "*${entityName}*" | fieldsAdd entity.type]

--- a/src/capabilities/get-events-for-cluster.ts
+++ b/src/capabilities/get-events-for-cluster.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { executeDql } from './execute-dql';
 
-export const getEventsForCluster = async (dtClient: _OAuthHttpClient, clusterId: string) => {
+export const getEventsForCluster = async (dtClient: HttpClient, clusterId: string) => {
   let dql = `fetch events | filter k8s.cluster.uid == "${clusterId}"`;
 
   if (!clusterId) {

--- a/src/capabilities/get-logs-for-entity.ts
+++ b/src/capabilities/get-logs-for-entity.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { executeDql } from './execute-dql';
 
-export const getLogsForEntity = async (dtClient: _OAuthHttpClient, entityId: string) => {
+export const getLogsForEntity = async (dtClient: HttpClient, entityId: string) => {
   const dql = `fetch logs | filter dt.source_entity == "${entityId}"`;
 
   return executeDql(dtClient, dql);

--- a/src/capabilities/get-monitored-entity-details.ts
+++ b/src/capabilities/get-monitored-entity-details.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { MonitoredEntitiesClient } from '@dynatrace-sdk/client-classic-environment-v2';
 
-export const getMonitoredEntityDetails = async (dtClient: _OAuthHttpClient, entityId: string) => {
+export const getMonitoredEntityDetails = async (dtClient: HttpClient, entityId: string) => {
   const monitoredEntitiesClient = new MonitoredEntitiesClient(dtClient);
 
   const entityDetails = await monitoredEntitiesClient.getEntity({

--- a/src/capabilities/get-ownership-information.ts
+++ b/src/capabilities/get-ownership-information.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { callAppFunction } from './call-app-function';
 
-export const getOwnershipInformation = async (dtClient: _OAuthHttpClient, entityIds: string) => {
+export const getOwnershipInformation = async (dtClient: HttpClient, entityIds: string) => {
   const ownershipResponse = await callAppFunction(dtClient, 'dynatrace.ownership', 'get-ownership-from-entity', {
     entityIds: entityIds,
   });

--- a/src/capabilities/get-problem-details.ts
+++ b/src/capabilities/get-problem-details.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { ProblemsClient } from '@dynatrace-sdk/client-classic-environment-v2';
 
-export const getProblemDetails = async (dtClient: _OAuthHttpClient, problemId: string) => {
+export const getProblemDetails = async (dtClient: HttpClient, problemId: string) => {
   console.error(`Fetchin problem with problemId ${problemId}`);
   const problemsClient = new ProblemsClient(dtClient);
   const problemDetails = await problemsClient.getProblem({

--- a/src/capabilities/get-vulnerability-details.ts
+++ b/src/capabilities/get-vulnerability-details.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { SecurityProblemsClient } from '@dynatrace-sdk/client-classic-environment-v2';
 
-export const getVulnerabilityDetails = async (dtClient: _OAuthHttpClient, securityProblemId: string) => {
+export const getVulnerabilityDetails = async (dtClient: HttpClient, securityProblemId: string) => {
   const securityProblemsClient = new SecurityProblemsClient(dtClient);
 
   const response = await securityProblemsClient.getSecurityProblem({

--- a/src/capabilities/list-problems.ts
+++ b/src/capabilities/list-problems.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { ProblemsClient } from '@dynatrace-sdk/client-classic-environment-v2';
 
-export const listProblems = async (dtClient: _OAuthHttpClient) => {
+export const listProblems = async (dtClient: HttpClient) => {
   const problemsClient = new ProblemsClient(dtClient);
 
   const securityProblems = await problemsClient.getProblems({

--- a/src/capabilities/list-vulnerabilities.ts
+++ b/src/capabilities/list-vulnerabilities.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { SecurityProblemsClient } from '@dynatrace-sdk/client-classic-environment-v2';
 
-export const listVulnerabilities = async (dtClient: _OAuthHttpClient) => {
+export const listVulnerabilities = async (dtClient: HttpClient) => {
   const securityProblemsClient = new SecurityProblemsClient(dtClient);
 
   const response = await securityProblemsClient.getSecurityProblems({

--- a/src/capabilities/send-slack-message.ts
+++ b/src/capabilities/send-slack-message.ts
@@ -1,8 +1,8 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { callAppFunction } from './call-app-function';
 
 export const sendSlackMessage = async (
-  dtClient: _OAuthHttpClient,
+  dtClient: HttpClient,
   connectionId: string,
   channel: string,
   message: string,

--- a/src/capabilities/update-workflow.ts
+++ b/src/capabilities/update-workflow.ts
@@ -1,7 +1,7 @@
-import { _OAuthHttpClient } from '@dynatrace-sdk/http-client';
+import { HttpClient } from '@dynatrace-sdk/http-client';
 import { WorkflowsClient } from '@dynatrace-sdk/client-automation';
 
-export const updateWorkflow = async (dtClient: _OAuthHttpClient, workflowId: string, body: any) => {
+export const updateWorkflow = async (dtClient: HttpClient, workflowId: string, body: any) => {
   const workflowsclient = new WorkflowsClient(dtClient);
 
   return await workflowsclient.updateWorkflow({

--- a/src/getDynatraceEnv.test.ts
+++ b/src/getDynatraceEnv.test.ts
@@ -5,6 +5,7 @@ describe('getDynatraceEnv', () => {
     OAUTH_CLIENT_ID: 'dt0s02.SAMPLE',
     OAUTH_CLIENT_SECRET: 'dt0s02.SAMPLE.abcd1234',
     DT_ENVIRONMENT: 'https://abc123.apps.dynatrace.com',
+    DT_PLATFORM_TOKEN: 'dt0s16.SAMPLE.abcd1234',
     SLACK_CONNECTION_ID: 'slack-conn-id',
   };
 
@@ -12,9 +13,10 @@ describe('getDynatraceEnv', () => {
     const env = { ...baseEnv };
     const result = getDynatraceEnv(env);
     expect(result).toEqual({
-      oauthClient: env.OAUTH_CLIENT_ID,
+      oauthClientId: env.OAUTH_CLIENT_ID,
       oauthClientSecret: env.OAUTH_CLIENT_SECRET,
       dtEnvironment: env.DT_ENVIRONMENT,
+      dtPlatformToken: env.DT_PLATFORM_TOKEN,
       slackConnectionId: env.SLACK_CONNECTION_ID,
     });
   });
@@ -25,14 +27,14 @@ describe('getDynatraceEnv', () => {
     expect(result.slackConnectionId).toBe('fake-slack-connection-id');
   });
 
-  it('throws if OAUTH_CLIENT_ID is missing', () => {
-    const env = { ...baseEnv, OAUTH_CLIENT_ID: undefined };
+  it('throws if environment variables for auth credentials are missing', () => {
+    const env = {
+      ...baseEnv,
+      OAUTH_CLIENT_ID: undefined,
+      OAUTH_CLIENT_SECRET: undefined,
+      DT_PLATFORM_TOKEN: undefined,
+    };
     expect(() => getDynatraceEnv(env)).toThrow(/OAUTH_CLIENT_ID/);
-  });
-
-  it('throws if OAUTH_CLIENT_SECRET is missing', () => {
-    const env = { ...baseEnv, OAUTH_CLIENT_SECRET: undefined };
-    expect(() => getDynatraceEnv(env)).toThrow(/OAUTH_CLIENT_SECRET/);
   });
 
   it('throws if DT_ENVIRONMENT is missing', () => {

--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -1,7 +1,8 @@
 // Helper to validate and extract required environment variables for Dynatrace MCP
 export interface DynatraceEnv {
-  oauthClient: string;
-  oauthClientSecret: string;
+  oauthClientId?: string;
+  oauthClientSecret?: string;
+  dtPlatformToken?: string;
   dtEnvironment: string;
   slackConnectionId: string;
 }
@@ -11,13 +12,20 @@ export interface DynatraceEnv {
  * Throws an Error if validation fails.
  */
 export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): DynatraceEnv {
-  const oauthClient = env.OAUTH_CLIENT_ID;
+  const oauthClientId = env.OAUTH_CLIENT_ID;
   const oauthClientSecret = env.OAUTH_CLIENT_SECRET;
+  const dtPlatformToken = env.DT_PLATFORM_TOKEN;
   const dtEnvironment = env.DT_ENVIRONMENT;
   const slackConnectionId = env.SLACK_CONNECTION_ID || 'fake-slack-connection-id';
 
-  if (!oauthClient || !oauthClientSecret || !dtEnvironment) {
-    throw new Error('Please set OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET and DT_ENVIRONMENT environment variables');
+  if (!dtEnvironment) {
+    throw new Error('Please set DT_ENVIRONMENT environment variable to your Dynatrace Platform Environment');
+  }
+
+  if (!oauthClientId && !oauthClientSecret && !dtPlatformToken) {
+    throw new Error(
+      'Please set either OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET, or DT_PLATFORM_TOKEN environment variables',
+    );
   }
 
   if (!dtEnvironment.startsWith('https://')) {
@@ -32,5 +40,5 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
     );
   }
 
-  return { oauthClient, oauthClientSecret, dtEnvironment, slackConnectionId };
+  return { oauthClientId, oauthClientSecret, dtPlatformToken, dtEnvironment, slackConnectionId };
 }


### PR DESCRIPTION
Added Preliminary Support for Platform Tokens (fixes #40).

Unfortunately, not all scopes are available for Platform Tokens. We might want to refactor some API Calls, but I'll defer that to later.

These are the changes I've done:

1. Refactored the whole authentication process, to no longer require the internal `_OAuthHttpClient`, and instead relying on the `PlatformHttpClient`.
2. Added a new environment variable `DT_PLATFORM_TOKEN`
3. Restructured README for Authentication and Scopes

I'm not too happy about the code in index.ts though, I think some refactoring for the authentication calls to create `dtClient` is needed.
