### PR TITLE
chore: Improved DevXP - added auto-reload to the local mcp server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,7 +3,7 @@
     "my-dynatrace-mcp-server": {
       "command": "node",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceFolder}/dist/index.js"],
+      "args": ["--watch", "${workspaceFolder}/dist/index.js"],
       "envFile": "${workspaceFolder}/.env"
     }
   }

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ First, enable Copilot for your Workspace `.vscode/settings.json`:
 }
 ```
 
+and make sure that you are using Agent Mode in CoPilot.
+
 Second, add the MCP to `.vscode/mcp.json`:
 
 ```json
@@ -292,7 +294,7 @@ Second, add the MCP to `.vscode/mcp.json`:
   "servers": {
     "my-dynatrace-mcp-server": {
       "command": "node",
-      "args": ["${workspaceFolder}/dist/index.js"],
+      "args": ["--watch", "${workspaceFolder}/dist/index.js"],
       "envFile": "${workspaceFolder}/.env"
     }
   }
@@ -301,7 +303,7 @@ Second, add the MCP to `.vscode/mcp.json`:
 
 Third, create a `.env` file in this repository (you can copy from `.env.template`) and configure environment variables as [described above](#environment-variables).
 
-Last but not least, switch to Agent Mode in CoPilot and reload tools.
+Finally, make changes to your code and compile it with `npm run build` or just run `npm run watch` and it auto-compiles.
 
 ## Notes
 


### PR DESCRIPTION
With this PR, I'm adding an auto-reload feature to the local mcp server that we use in `.vscode/mcp.json`.

By leveraging the `--watch` command of Node, it will automatically reload once a change is detected in dist/index.js or the required files.

**Try it out**

* Open in VSCode
* Start the MCP Server via VSCode UI
* In a terminal Window, run `npm run watch`
* Make some changes to the code (e.g., add a new tool)
* Check if those changes get propagated by trying them out, e.g., via CoPilot
