### PR TITLE
chore: Fix release workflow running unit tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run prettier
 
       - name: Run tests
-        run: npm run test
+        run: npm run test:unit
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Fixes failed release Workflow: https://github.com/dynatrace-oss/dynatrace-mcp/actions/runs/16479507541/job/46589802585

This was caused by [my PR](https://github.com/dynatrace-oss/dynatrace-mcp/pull/63/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3), where I changed from  `test` to `test:unit`, but forgot to do it in the release workflow.