### PR TITLE
patch: Improve verify_dql tool description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 
 - Removed unneeded scopes `environment-api:slo:read` (no tool is using this) and `environment-api:metrics:read` (anyway handled via execute DQL tool)
+- Removed `metrics` from `execute_dql` example with `fetch`.
+- Clarified usage of `verify_dql` to avoid unnecessary tool calls.
 
 ## 0.5.0 (Release Candidate 2)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,7 +375,7 @@ const main = async () => {
 
   tool(
     'verify_dql',
-    'Verify a Dynatrace Query Language (DQL) statement on Dynatrace GRAIL before executing it. This is useful to ensure that the DQL statement is valid and can be executed without errors.',
+    'Verify a Dynatrace Query Language (DQL) statement on Dynatrace GRAIL before executing it. This step is recommended for DQL statements that have been dynamically created by non-expert tools. For statements coming from the `generate_dql_from_natural_language` tool as well as from documentation, this step can be omitted.',
     {
       dqlStatement: z.string(),
     },
@@ -410,7 +410,7 @@ const main = async () => {
 
   tool(
     'execute_dql',
-    'Get Logs, Metrics, Spans or Events from Dynatrace GRAIL by executing a Dynatrace Query Language (DQL) statement. Always use "verify_dql" tool before you execute a DQL statement. A valid statement looks like this: "fetch [logs, spans, events] | filter <some-filter> | summarize count(), by:{some-fields}. Adapt filters for certain attributes: `traceId` could be `trace_id` or `trace.id`.',
+    'Get Logs, Metrics, Spans or Events from Dynatrace GRAIL by executing a Dynatrace Query Language (DQL) statement. It\'s recommended to use "verify_dql" tool before you execute a DQL statement. A valid statement looks like this: "fetch [logs, spans, events] | filter <some-filter> | summarize count(), by:{some-fields}. Adapt filters for certain attributes: `traceId` could be `trace_id` or `trace.id`.',
     {
       dqlStatement: z.string(),
     },
@@ -442,7 +442,7 @@ const main = async () => {
 
   tool(
     'generate_dql_from_natural_language',
-    "Convert natural language queries to Dynatrace Query Language (DQL) using Davis CoPilot AI. You can ask for problem events, security issues, logs, metrics, spans, and custom data. Workflow: 1) Generate DQL, 2) Verify with verify_dql tool, 3) Execute with execute_dql tool, 4) Iterate if results don't match expectations.",
+    'Convert natural language queries to Dynatrace Query Language (DQL) using Davis CoPilot AI. You can ask for problem events, security issues, logs, metrics, spans, and custom data.',
     {
       text: z
         .string()
@@ -475,9 +475,8 @@ const main = async () => {
       }
 
       resp += `\n💡 **Next Steps:**\n`;
-      resp += `1. Use "verify_dql" tool to validate this query\n`;
-      resp += `2. Use "execute_dql" tool to run the query\n`;
-      resp += `3. If results don't match expectations, refine your natural language description and try again\n`;
+      resp += `1. Use "execute_dql" tool to run the query (you can ommit running the "verify_dql" tool)\n`;
+      resp += `2. If results don't match expectations, refine your natural language description and try again\n`;
 
       return resp;
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,7 +475,7 @@ const main = async () => {
       }
 
       resp += `\n💡 **Next Steps:**\n`;
-      resp += `1. Use "execute_dql" tool to run the query (you can ommit running the "verify_dql" tool)\n`;
+      resp += `1. Use "execute_dql" tool to run the query (you can omit running the "verify_dql" tool)\n`;
       resp += `2. If results don't match expectations, refine your natural language description and try again\n`;
 
       return resp;


### PR DESCRIPTION
This should improve when and how often the verify_dql endpoint is called, as it's not needed when we get pre-verified queries.

<img width="852" height="350" alt="image" src="https://github.com/user-attachments/assets/9927429a-a279-432d-86b4-6ad5c07bdd45" />
