### PR TITLE
chore: Prepare release v0.5.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @dynatrace-oss/dynatrace-mcp-server
 
-## Unreleased changes
+## 0.5.0 (Release Candidate 3)
 
 - Improved `list_vulnerabilities` tool to use DQL statement instead of classic API, and aligned parameters with `list_problems` tool
 - Removed `get_vulnerability_details` tool as the same can now be achieved with a simple `execute_dql` call

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.5.0-rc.2",
+  "version": "0.5.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "0.5.0-rc.2",
+      "version": "0.5.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-automation": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.5.0-rc.2",
+  "version": "0.5.0-rc.3",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [
     "Dynatrace",


### PR DESCRIPTION
Preparing release v0.5.0-rc.3

See CHANGELOG.md for details, but basically this contains the next step in converting the "old" `environment-api` calls to DQL statements.