### PR TITLE
chore: Remove reviewers and assignee from dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
       time: '06:00'
       timezone: 'UTC'
     open-pull-requests-limit: 10
-    reviewers:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
-    assignees:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
     commit-message:
       prefix: 'deps'
       prefix-development: 'deps-dev'
@@ -53,10 +49,6 @@ updates:
       time: '06:00'
       timezone: 'UTC'
     open-pull-requests-limit: 5
-    reviewers:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
-    assignees:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
     commit-message:
       prefix: 'ci'
       include: 'scope'
@@ -73,10 +65,6 @@ updates:
       time: '06:00'
       timezone: 'UTC'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
-    assignees:
-      - 'dynatrace-oss/dynatrace-mcp-maintainers'
     commit-message:
       prefix: 'docker'
       include: 'scope'


### PR DESCRIPTION
This should fix the message we are getting on dependabot PR:
<img width="1244" height="185" alt="image" src="https://github.com/user-attachments/assets/df4e1308-9fa9-49ac-98fd-98b4a6fab1ca" />
