### PR TITLE
chore: Update NodeJS Update strategy in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,7 @@ updates:
       - dependency-name: 'dt-app'
         update-types: ['version-update:semver-major']
       # Node.js version policy: Only allow LTS versions and be conservative about upgrades
-      # Current: Node.js 22 (LTS until April 2027)
+      # Current: Node.js 22 (LTS until October 2025)
       # Ignore non-LTS Node.js versions (odd-numbered major versions)
       - dependency-name: 'node'
         versions: ['23.x', '25.x', '27.x', '29.x', '31.x', '33.x']


### PR DESCRIPTION
Created a separate NodeJS Group for dependabot.

Also, we are ignoring an immediate update to NodeJS 24, as long as version 22 is LTS.
<img width="767" height="948" alt="image" src="https://github.com/user-attachments/assets/f87a9fd3-9f83-42eb-9f9e-f5559da09079" />
