### PR TITLE
patch: Added dtClientContext to execute_dql to allow cost and usage monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased Changes
 
+- Added cost considerations disclaimer in README about Dynatrace Grail data access.
+- Added `dtClientContext` to `execute_dql` tool, to allow usage-monitoring for Grail access.
+
 ## 0.5.0 (Release Candidate 4)
 
 - Added Streamable HTTP transport support with `--http`/`--server`, `--port`, and `--host` arguments (default remains stdio for backward compatibility)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Bring real-time observability data directly into your development workflow.
 - Get more information about a monitored entity
 - Get Ownership of an entity
 
+## Costs
+
+**Important:** While this local MCP server is provided for free, using it to access data in Dynatrace Grail may incur additional costs based
+on your Dynatrace consumption model. This affects `execute_dql` tool and other capabilities that **query** Dynatrace Grail storage, and costs
+depend on the volume (GB scanned/billed).
+
+**Before using this MCP server extensively, please:**
+
+1. Review your current Dynatrace consumption model and pricing
+2. Understand the cost implications of the specific data you plan to query (logs, events, metrics) - see [Dynatrace Pricing and Rate Card](https://www.dynatrace.com/pricing/)
+3. Start with smaller timeframes (e.g., 12h-24h) and make use of [buckets](https://docs.dynatrace.com/docs/discover-dynatrace/platform/grail/data-model#built-in-grail-buckets) to reduce the cost impact
+
+**Note**: We will be providing a way to monitor Query Usage of the dynatrace-mcp-server in the future.
+
 ### AI-Powered Assistance (Preview)
 
 - **Natural Language to DQL** - Convert plain English queries to Dynatrace Query Language

--- a/src/authentication/dynatrace-clients.ts
+++ b/src/authentication/dynatrace-clients.ts
@@ -1,6 +1,6 @@
 import { HttpClient, PlatformHttpClient } from '@dynatrace-sdk/http-client';
 import { getSSOUrl } from 'dt-app';
-import { version as VERSION } from '../../package.json';
+import { getUserAgent } from '../utils/user-agent';
 import { OAuthTokenResponse } from './types';
 
 /**
@@ -73,7 +73,7 @@ const createBearerTokenHttpClient = async (environmentUrl: string, dtPlatformTok
     baseUrl: environmentUrl,
     defaultHeaders: {
       'Authorization': `Bearer ${dtPlatformToken}`,
-      'User-Agent': `dynatrace-mcp-server/v${VERSION} (${process.platform}-${process.arch})`,
+      'User-Agent': getUserAgent(),
     },
   });
 };

--- a/src/capabilities/execute-dql.ts
+++ b/src/capabilities/execute-dql.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@dynatrace-sdk/http-client';
 import { QueryExecutionClient, QueryAssistanceClient, QueryResult, ExecuteRequest } from '@dynatrace-sdk/client-query';
+import { getUserAgent } from '../utils/user-agent';
 
 export const verifyDqlStatement = async (dtClient: HttpClient, dqlStatement: string) => {
   const queryAssistanceClient = new QueryAssistanceClient(dtClient);
@@ -27,7 +28,10 @@ export const executeDql = async (
 ): Promise<QueryResult['records'] | undefined> => {
   const queryExecutionClient = new QueryExecutionClient(dtClient);
 
-  const response = await queryExecutionClient.queryExecute({ body });
+  const response = await queryExecutionClient.queryExecute({
+    body,
+    dtClientContext: getUserAgent(),
+  });
 
   if (response.result) {
     // return response result immediately
@@ -42,6 +46,7 @@ export const executeDql = async (
       await new Promise((resolve) => setTimeout(resolve, 2000));
       pollResponse = await queryExecutionClient.queryPoll({
         requestToken: response.requestToken,
+        dtClientContext: getUserAgent(),
       });
       // done - let's return it
       if (pollResponse.result) {

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,0 +1,9 @@
+import { version as VERSION } from '../../package.json';
+
+/**
+ * Generate a user agent string for Dynatrace MCP Server
+ * @returns User agent string in format: dynatrace-mcp-server/vX.X.X (platform-arch)
+ */
+export const getUserAgent = (): string => {
+  return `dynatrace-mcp-server/v${VERSION} (${process.platform}-${process.arch})`;
+};


### PR DESCRIPTION
With this PR, we are enabling cost and usage monitoring for our users.

Example Query (for now):
```
fetch dt.system.events
| filter isNull(client.application_context)
| filter contains(client.client_context, "dynatrace-mcp")
```

I'm not documenting this query for the time being, as this will not be useful at all at the time being. First, we need users adopt these changes (which will be part of the upcoming 0.5.0 release).

