### PR TITLE
feat: Added next steps for get_entity_details tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 
 - Added metadata output which includes scanned bytes (for cost tracking) to `execute_dql`
+- Added next-steps for `get_entity_details` to find out about metrics, problems and logs
 
 ## 0.5.0
 

--- a/src/capabilities/get-monitored-entity-details.ts
+++ b/src/capabilities/get-monitored-entity-details.ts
@@ -2,7 +2,13 @@ import { HttpClient } from '@dynatrace-sdk/http-client';
 import { executeDql } from './execute-dql';
 import { getEntityTypeFromId } from '../utils/dynatrace-entity-types';
 
-type MonitoredEntityDetails = { entityId: string; displayName: string; type: string; allProperties: any };
+type MonitoredEntityDetails = {
+  entityId: string;
+  displayName: string;
+  entityTypeTable: string;
+  type: string;
+  allProperties: any;
+};
 
 /**
  * Get monitored entity details by entity ID via DQL
@@ -53,6 +59,7 @@ export const getMonitoredEntityDetails = async (
   // return entity details
   return {
     entityId: String(entity.id),
+    entityTypeTable: entityType,
     displayName: String(entity['entity.name']),
     type: String(entity['entity.type']),
     allProperties: entity || undefined,


### PR DESCRIPTION
Essentially, we can now run the following prompt: "I want to know more about my app "dynatrace.slack" - metrics, logs, events"

And we will get an exhausitve answer 🤯 

<img width="930" height="1172" alt="image" src="https://github.com/user-attachments/assets/cd18e93d-6932-4068-bcf4-1bdff1233b54" />
<img width="935" height="494" alt="image" src="https://github.com/user-attachments/assets/860f4911-f586-4954-915e-774a7b64d58c" />

