### PR TITLE
feat: Added server.json to prepare publishing to MCP registry

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -12,6 +12,7 @@ When preparing a release, follow these steps to ensure everything is in order:
 4. Create a new section in CHANGELOG.md for the version below "Unreleased Changes".
 5. Move all entries from "Unreleased Changes" to this new section. Reword them in the process to fit the content guidelines specified in `.github/instructions/changelog.instructions.md`.
 6. Update the version number in `package.json`.
-7. Run `npm install --package-lock-only` to sync the lock file.
-8. Let the user verify the release notes and version number before proceeding.
-9. Commit the changes with a message like `chore(release): prepare for <version> release`.
+7. Update the version number in `server.json`.
+8. Run `npm install --package-lock-only` to sync the lock file.
+9. Let the user verify the release notes and version number before proceeding.
+10. Commit the changes with a message like `chore(release): prepare for <version> release`.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules/
 .DS_Store
 
 tsconfig.tsbuildinfo
+
+# mcp registry
+.mcpregistry_github_token
+.mcpregistry_registry_token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added metadata output which includes scanned bytes (for cost tracking) to `execute_dql`
 - Added next-steps for `get_entity_details` to find out about metrics, problems and logs
 - Added Telemetry via Dynatrace OpenKit to improve the product with anonymous usage statistics and error information (can be disabled via `DT_MCP_DISABLE_TELEMETRY` environment variable)
+- Added `server.json` and published the mcp server at the official MCP Registry
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # Dynatrace MCP Server
 
+<h4 align="center">
+  <a href="https://github.com/dynatrace-oss/dynatrace-mcp/releases">
+    <img src="https://img.shields.io/github/release/dynatrace-oss/dynatrace-mcp" />
+  </a>
+  <a href="https://github.com/dynatrace-oss/dynatrace-mcp/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-mit-blue.svg" alt="Dynatrace MCP Server is released under the MIT License" />
+  </a>
+  <a href="https://www.npmjs.com/package/@dynatrace-oss/dynatrace-mcp-server">
+    <img src="https://img.shields.io/npm/dm/@dynatrace-oss/dynatrace-mcp-server?logo=npm&style=flat&color=red" alt="npm" />
+  </a>
+  <a href="https://github.com/dynatrace-oss/dynatrace-mcp">
+    <img src="https://img.shields.io/github/stars/dynatrace-oss/dynatrace-mcp" alt="Dynatrace MCP Server Stars on GitHub" />
+  </a>
+  <a href="https://github.com/dynatrace-oss/dynatrace-mcp">
+    <img src="https://img.shields.io/github/contributors/dynatrace-oss/dynatrace-mcp?color=green" alt="Dynatrace MCP Server Contributors on GitHub" />
+  </a>
+</h4>
+
 This local MCP server allows interaction with the [Dynatrace](https://www.dynatrace.com/) observability platform.
 Bring real-time observability data directly into your development workflow.
+
+> Note: This product is not officially supported by Dynatrace.
+
+Please contact us via [GitHub Issues](https://github.com/dynatrace-oss/dynatrace-mcp/issues) if you have feature requests, questions, or need help.
 
 <img width="1046" alt="image" src="/assets/dynatrace-mcp-arch.png" />
 
@@ -195,7 +217,7 @@ This only works if the config is stored in the current workspaces, e.g., `<your-
 ```json
 {
   "mcpServers": {
-    "mobile-mcp": {
+    "dynatrace-mcp-server": {
       "command": "npx",
       "args": ["-y", "@dynatrace-oss/dynatrace-mcp-server@latest"],
       "env": {
@@ -214,7 +236,7 @@ The [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdevelop
 ```json
 {
   "mcpServers": {
-    "mobile-mcp": {
+    "dynatrace-mcp-server": {
       "command": "npx",
       "args": ["-y", "@dynatrace-oss/dynatrace-mcp-server@latest"],
       "env": {
@@ -628,8 +650,3 @@ This will
 - prepare the [changelog](CHANGELOG.md),
 - update the version number in [package.json](package.json),
 - commit the changes.
-
-## Notes
-
-This product is not officially supported by Dynatrace.
-Please contact us via [GitHub Issues](https://github.com/dynatrace-oss/dynatrace-mcp/issues) if you have feature requests, questions, or need help.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
   "version": "0.5.0",
+  "mcpName": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [
     "Dynatrace",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.dynatrace-oss/Dynatrace-mcp",
+  "description": "Model Context Protocol server for Dynatrace - access logs, events, metrics from Dynatrace via MCP.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
+    "source": "github"
+  },
+  "version": "0.5.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@dynatrace-oss/dynatrace-mcp-server",
+      "version": "0.5.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "description": "Your Dynatrace Platform Token",
+          "is_required": true,
+          "format": "string",
+          "is_secret": true,
+          "name": "DT_PLATFORM_TOKEN"
+        },
+        {
+          "description": "The URL of your Dynatrace environment (e.g. 'https://abc12345.apps.dynatrace.com')",
+          "is_required": false,
+          "format": "string",
+          "name": "DT_ENVIRONMENT"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Goal**: Increase visibility and reach of the dynatrace-mcp-server, by publishing it to the official MCP Registry.

* Created `server.json` based on https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md, and tried to publish it to the MCP registry from my local PC (which unfortunately failed due to authentication issues - that will be another story).
* Added some img-shields on top of the README, as those are great visuals and are visible immediately when somebody shows the README (e.g., in VSCode marketplace).
* Moved the disclaimer about support on top.

<img width="1250" height="356" alt="image" src="https://github.com/user-attachments/assets/0fd5d4e7-523e-4c29-8af6-c498eb6af6a9" />
