### PR TITLE
chore: Added MCP registry publishing workflows to GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,3 +103,16 @@ jobs:
               --title "Release ${{ steps.version.outputs.tag }}" \
               --notes-file release_body.md
           fi
+
+      # From https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # Login to GitHub - apparently this works out of the box with GH Workflows
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      # Publish the package to the MCP Registry
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
**Note**: Depends on https://github.com/dynatrace-oss/dynatrace-mcp/pull/146  - will be rebased once the other PR got merged.

Within this PR, I've added the GitHub Action based publishing Workflow for publishing to the official MCP Registry, as detailed on https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md

