### PR TITLE
chore: Fix server.json for mcp registry to include a runtime-hint

### DIFF
--- a/server.json
+++ b/server.json
@@ -14,6 +14,7 @@
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
       "version": "0.6.0-rc.1",
+      "runtime_hint": "npx",
       "transport": {
         "type": "stdio"
       },
@@ -27,7 +28,7 @@
         },
         {
           "description": "The URL of your Dynatrace environment (e.g. 'https://abc12345.apps.dynatrace.com')",
-          "is_required": false,
+          "is_required": true,
           "format": "string",
           "name": "DT_ENVIRONMENT"
         }


### PR DESCRIPTION
Noticed in other examples that they have the runtime hint, which is not strictly necessary, but probably a good thing to have.
See https://github.com/modelcontextprotocol/registry/blob/63cf08efad6ec056cf7c174221db25572a429385/docs/reference/api/openapi.yaml#L306-L308 for reference.