### PR TITLE
fix: README.md architecture link not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Bring real-time observability data directly into your development workflow.
 
 Please contact us via [GitHub Issues](https://github.com/dynatrace-oss/dynatrace-mcp/issues) if you have feature requests, questions, or need help.
 
-![Architecture](https://github.com/dynatrace-oss/dynatrace-mcp/blob/main//assets/dynatrace-mcp-arch.png?raw=true)
+![Architecture](https://github.com/dynatrace-oss/dynatrace-mcp/blob/main/assets/dynatrace-mcp-arch.png?raw=true)
 
 ## Use cases
 


### PR DESCRIPTION
This should fix the picture not being shown properly in GitHub marketplace:
<img width="1308" height="587" alt="image" src="https://github.com/user-attachments/assets/16372acb-91fd-4600-9241-6368151c8488" />
