### PR TITLE
patch: Added Gemini Extension and CLI Support in README

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -11,8 +11,7 @@ When preparing a release, follow these steps to ensure everything is in order:
 3. Work on a release branch, typically named `chore/prepare-release-<version>`.
 4. Create a new section in CHANGELOG.md for the version below "Unreleased Changes".
 5. Move all entries from "Unreleased Changes" to this new section. Reword them in the process to fit the content guidelines specified in `.github/instructions/changelog.instructions.md`.
-6. Update the version number in `package.json`.
-7. Update the version number in `server.json`.
-8. Run `npm install --package-lock-only` to sync the lock file.
-9. Let the user verify the release notes and version number before proceeding.
-10. Commit the changes with a message like `chore(release): prepare for <version> release`.
+6. Update the version number in `package.json`, `server.json`, and `gemini-extension.json`.
+7. Run `npm install --package-lock-only` to sync the lock file.
+8. Let the user verify the release notes and version number before proceeding.
+9. Commit the changes with a message like `chore(release): prepare for <version> release`.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,43 @@ The [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdevelop
 
 This configuration should be stored in `<your-repo>/.amazonq/mcp.json`.
 
+**Google Gemini CLI**
+
+The [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) is Google's official command-line AI assistant that supports MCP server integration. You can add the Dynatrace MCP server using either the built-in management commands or manual configuration.
+
+Using `gemini` CLI directly (recommended):
+
+```bash
+gemini extensions install https://github.com/dynatrace-oss/dynatrace-mcp
+export DT_PLATFORM_TOKEN=...
+export DT_ENVIRONMENT=https://...
+```
+
+and verify that the server is running via
+
+```bash
+gemini mcp list
+```
+
+Or manually in your `~/.gemini/settings.json` or `.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "dynatrace": {
+      "command": "npx",
+      "args": ["@dynatrace-oss/dynatrace-mcp-server@latest"],
+      "env": {
+        "DT_PLATFORM_TOKEN": "",
+        "DT_ENVIRONMENT": ""
+      },
+      "timeout": 30000,
+      "trust": false
+    }
+  }
+}
+```
+
 ### HTTP Server Mode (Alternative)
 
 For scenarios where you need to run the MCP server as an HTTP service instead of using stdio (e.g., for stateful sessions, load balancing, or integration with web clients), you can use the HTTP server mode:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,10 @@
+{
+  "name": "dynatrace-mcp-server",
+  "version": "0.6.0",
+  "mcpServers": {
+    "dynatrace": {
+      "command": "npx",
+      "args": ["-y", "@dynatrace-oss/dynatrace-mcp-server@latest"]
+    }
+  }
+}


### PR DESCRIPTION
Adding Gemini CLI Support

to try it out:

**Setup Gemini CLI First** (btw, you'll need a google account)
```bash
# install it
npm install -g @google/gemini-cli
```

**Install the extension** (I did it locally, but the plan is to use the github.com URL in the end)
```bash
gemini extensions install --path ../dynatrace-mcp/
```
This should output something like
```
Extension "dynatrace-mcp-server" installed successfully and enabled.
```

Configure it:
```bash
export DT_PLATFORM_TOKEN=...
export DT_ENVIRONMENT=...
```

Now check if the extension is available
```bash
gemini mcp list
```

In theory, you should be able to start gemini, and use the tools:
```bash
gemini
# in gemini
Which Dynatrace environment am I connected to?
```

<img width="1382" height="608" alt="image" src="https://github.com/user-attachments/assets/ce79a265-9a3b-4521-ab1a-01b97693cb84" />
