### PR TITLE
fix: Fixed an issue with MCP communication failing due to dotenv.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # @dynatrace-oss/dynatrace-mcp-server
 
-## Unreleased Changes
+## 0.6.1
+
+- Fixed an issue with MCP communication failing with `SyntaxError: Unexpected token 'd'` due to `dotenv`
+- Added Support for Google Gemini CLI
 
 ## 0.6.0
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpServers": {
     "dynatrace": {
       "command": "npx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-automation": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpName": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,22 @@ import { Http2ServerRequest } from 'node:http2';
 import { resetGrailBudgetTracker, getGrailBudgetTracker } from './utils/grail-budget-tracker';
 import { read } from 'node:fs';
 
-config();
+// Load environment variables from .env file if available, and suppress warnings/logging to stdio
+// as it breaks MCP communication when using stdio transport
+const dotEnvOutput = config({ quiet: true });
+
+if (dotEnvOutput.error) {
+  // Only log error if it's not about missing .env file
+  if ((dotEnvOutput.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+    console.error('Error loading .env file:', dotEnvOutput.error);
+    process.exit(1);
+  }
+} else {
+  // Successfully loaded .env file
+  console.error(
+    `.env file loaded successfully - loaded ${dotEnvOutput.parsed ? Object.keys(dotEnvOutput.parsed).length : 0} environment variables: ${Object.keys(dotEnvOutput.parsed || {}).join(', ')}`,
+  );
+}
 
 let scopesBase = [
   'app-engine:apps:run', // needed for environmentInformationClient


### PR DESCRIPTION
With version 17 of `dotenv`, the author started printing messages to `stdout`, which is... not great.

We are now suppressing this messages by adding `quiet: true`, and handling any errors that might happen internally directly in our code. In addition, I'm writing what environment variables were loaded to `stderr` for troubleshooting purpose.