### PR TITLE
feat: Added human-approval step for send-email, send-slack-message, create-workflow and make-workflow-public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @dynatrace-oss/dynatrace-mcp-server
 
+## Unreleased Changes
+
+- Added human approval step via MCP's elicitation to ensure user consent before executing critical operations for the following tools:
+  - `send_email` (data sink)
+  - `send_slack_message` (data sink)
+  - `create_workflow_for_notification` (potentially destructive)
+  - `make_workflow_public` (potentially destructive)
+
 ## 0.6.1
 
 - Fixed an issue with MCP communication failing with `SyntaxError: Unexpected token 'd'` due to `dotenv`

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,6 @@ const main = async () => {
   /**
    * Helper function to request human approval for potentially sensitive operations
    * @param operation - Description of the operation requiring approval
-   * @param details - Detailed information about what will be performed
    * @returns Promise<boolean> - true if approved, false if declined or cancelled
    */
   const requestHumanApproval = async (operation: string): Promise<boolean> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import {
   NotificationSchema,
   Tool,
   ToolAnnotations,
+  ElicitRequest,
+  ElicitResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { config } from 'dotenv';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
@@ -195,6 +197,7 @@ const main = async () => {
     {
       capabilities: {
         tools: {},
+        elicitation: {},
       },
     },
   );
@@ -247,6 +250,41 @@ const main = async () => {
     };
 
     server.tool(name, description, paramsSchema, annotations, (args: z.ZodRawShape) => wrappedCb(args));
+  };
+
+  /**
+   * Helper function to request human approval for potentially sensitive operations
+   * @param operation - Description of the operation requiring approval
+   * @param details - Detailed information about what will be performed
+   * @returns Promise<boolean> - true if approved, false if declined or cancelled
+   */
+  const requestHumanApproval = async (operation: string): Promise<boolean> => {
+    try {
+      const result = await server.server.elicitInput({
+        message: `Please review: ${operation}`,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            approval: {
+              type: 'boolean',
+              title: 'Approve this operation?',
+              description: 'Select true to approve this operation, or false to decline.',
+              default: false,
+            },
+          },
+          required: ['approval'],
+        },
+      });
+
+      if (result.action === 'accept' && result.content?.approval === true) {
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      console.error('Failed to elicit human approval:', error);
+      return false; // Default to deny if elicitation fails
+    }
   };
 
   /** Tool Definitions below */
@@ -488,14 +526,25 @@ const main = async () => {
     'send_slack_message',
     'Sends a Slack message to a dedicated Slack Channel via Slack Connector on Dynatrace',
     {
-      channel: z.string().optional(),
-      message: z.string().optional(),
+      channel: z.string(),
+      message: z
+        .string()
+        .describe(
+          'Slack markdown supported. Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
+        ),
     },
     {
       // not read-only, not open-world, not destructive
       readOnlyHint: false,
     },
     async ({ channel, message }) => {
+      // Request human approval before sending the message
+      const approved = await requestHumanApproval(`Send information via Slack to ${channel}`);
+
+      if (!approved) {
+        return 'Operation cancelled: Human approval was not granted for sending this Slack message.';
+      }
+
       const dtClient = await createDtHttpClient(
         dtEnvironment,
         scopesBase.concat('app-settings:objects:read'),
@@ -820,6 +869,15 @@ const main = async () => {
       idempotentHint: false, // creating the same workflow multiple times is possible
     },
     async ({ problemType, teamName, channel, isPrivate }) => {
+      // ask for human approval
+      const approved = await requestHumanApproval(
+        `Create a workflow for notifying team ${teamName} via ${channel} about ${problemType} problems`,
+      );
+
+      if (!approved) {
+        return 'Operation cancelled: Human approval was not granted for creating this workflow.';
+      }
+
       const dtClient = await createDtHttpClient(
         dtEnvironment,
         scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
@@ -857,6 +915,15 @@ const main = async () => {
       idempotentHint: true, // making the same workflow public multiple times yields the same result
     },
     async ({ workflowId }) => {
+      // ask for human approval
+      const approved = await requestHumanApproval(
+        `Make workflow ${workflowId} publicly available to everyone on the Dynatrace Environment`,
+      );
+
+      if (!approved) {
+        return 'Operation cancelled: Human approval was not granted for making this workflow public.';
+      }
+
       const dtClient = await createDtHttpClient(
         dtEnvironment,
         scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
@@ -967,7 +1034,11 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
       ccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for CC recipients'),
       bccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for BCC recipients'),
       subject: z.string().describe('Subject line of the email'),
-      body: z.string().describe('Body content of the email (plain text only)'),
+      body: z
+        .string()
+        .describe(
+          'Body content of the email (plain text only). Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
+        ),
     },
     {
       openWorldHint: true, // email is as close to the open-world as we can get with our system
@@ -980,6 +1051,15 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
         throw new Error(
           `Total recipients (${totalRecipients}) exceeds maximum limit of 10 across TO, CC, and BCC fields`,
         );
+      }
+
+      // Request human approval before sending the email
+      const allRecipients = [...toRecipients, ...(ccRecipients || []), ...(bccRecipients || [])];
+
+      const approved = await requestHumanApproval(`Send information via Email to ${allRecipients.join(', ')}`);
+
+      if (!approved) {
+        return 'Operation cancelled: Human approval was not granted for sending this email.';
       }
 
       const dtClient = await createDtHttpClient(


### PR DESCRIPTION
In order to avoid unwanted and unauthorized sending of data, e.g., because of Prompt Injection, we are introducing a human in the loop. Furthermore, we are making sure that the message/body sent contains an information about sensitive data.

https://github.com/user-attachments/assets/68bd9379-655b-4ad7-bf3f-f0272a4fc499

Content-wise, this is what we get on the receiving end (no actual log data, just summaries! Awesome!)
<img width="766" height="794" alt="image" src="https://github.com/user-attachments/assets/7c17a3ab-7393-471b-b3eb-42c5ed2031be" />

