### PR TITLE
patch: Remove DQL Budget enforcement when a Dev or Hardening tenant is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+- DQL Grail budget is not enforced for tenants on Dynatrace-internal dev or hardening stages
 - Added human approval step via MCP's elicitation to ensure user consent before executing critical operations for the following tools:
   - `send_email` (data sink)
   - `send_slack_message` (data sink)

--- a/src/getDynatraceEnv.test.ts
+++ b/src/getDynatraceEnv.test.ts
@@ -79,4 +79,38 @@ describe('getDynatraceEnv', () => {
     };
     expect(() => getDynatraceEnv(env)).not.toThrow();
   });
+
+  it('Defaults the Grail Budget to 1000', () => {
+    const env = {
+      ...baseEnv,
+      GRAIL_BUDGET_GB: undefined,
+      DT_ENVIRONMENT: 'https://abc123.apps.dynatrace.com',
+    };
+    const result = getDynatraceEnv(env);
+    expect(result).toEqual({
+      oauthClientId: env.OAUTH_CLIENT_ID,
+      oauthClientSecret: env.OAUTH_CLIENT_SECRET,
+      dtEnvironment: env.DT_ENVIRONMENT,
+      dtPlatformToken: env.DT_PLATFORM_TOKEN,
+      slackConnectionId: env.SLACK_CONNECTION_ID,
+      grailBudgetGB: 1000, // Default value
+    });
+  });
+
+  it('Resets the Grail Budget if a dev/sprint URL is used', () => {
+    const env = {
+      ...baseEnv,
+      GRAIL_BUDGET_GB: undefined,
+      DT_ENVIRONMENT: 'https://abc123.dev.apps.dynatracelabs.com',
+    };
+    const result = getDynatraceEnv(env);
+    expect(result).toEqual({
+      oauthClientId: env.OAUTH_CLIENT_ID,
+      oauthClientSecret: env.OAUTH_CLIENT_SECRET,
+      dtEnvironment: env.DT_ENVIRONMENT,
+      dtPlatformToken: env.DT_PLATFORM_TOKEN,
+      slackConnectionId: env.SLACK_CONNECTION_ID,
+      grailBudgetGB: -1, // Default value for dynatracelabs.com
+    });
+  });
 });

--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -18,7 +18,7 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
   const dtPlatformToken = env.DT_PLATFORM_TOKEN;
   const dtEnvironment = env.DT_ENVIRONMENT;
   const slackConnectionId = env.SLACK_CONNECTION_ID || 'fake-slack-connection-id';
-  const grailBudgetGB = parseFloat(env.DT_GRAIL_QUERY_BUDGET_GB || '1000'); // Default to 1000 GB
+  let grailBudgetGB = parseFloat(env.DT_GRAIL_QUERY_BUDGET_GB || '1000'); // Default to 1000 GB
 
   if (!dtEnvironment) {
     throw new Error('Please set DT_ENVIRONMENT environment variable to your Dynatrace Platform Environment');
@@ -30,9 +30,16 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
     );
   }
 
+  // For dev and hardening stages, set unlimited budget (-1) unless explicitly overridden
+  if (dtEnvironment.includes('apps.dynatracelabs.com') && !env.DT_GRAIL_QUERY_BUDGET_GB) {
+    grailBudgetGB = -1;
+  }
+
   // ToDo: Allow the case of -1 for unlimited Budget
-  if (isNaN(grailBudgetGB) || (grailBudgetGB <= 0 && grailBudgetGB !== -1)) {
-    throw new Error('DT_GRAIL_QUERY_BUDGET_GB must be a positive number representing GB budget for Grail queries');
+  if (isNaN(grailBudgetGB) || (grailBudgetGB < 0 && grailBudgetGB !== -1)) {
+    throw new Error(
+      'DT_GRAIL_QUERY_BUDGET_GB must be a positive number or -1 (for unlimited) representing GB budget for Grail queries',
+    );
   }
 
   if (!dtEnvironment.startsWith('https://')) {


### PR DESCRIPTION
We got feedback that the Grail Budget enforcement is not great (internally).
I'd like to keep *a* default value (maybe we increase it from 1000 to 2000) for prod/live/customer environments though to keep costs under control. Maybe we can even come up with something automatic here.

Open for discussions on that matter.