### PR TITLE
patch: Added a limit to get_kubernetes_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Added a limit argument to `get_kubernetes_events`
+
 ## 0.7.0
 
 **Highlights**

--- a/src/capabilities/get-events-for-cluster.ts
+++ b/src/capabilities/get-events-for-cluster.ts
@@ -1,13 +1,29 @@
 import { HttpClient } from '@dynatrace-sdk/http-client';
 import { executeDql } from './execute-dql';
 
-export const getEventsForCluster = async (dtClient: HttpClient, clusterId: string) => {
-  let dql = `fetch events | filter k8s.cluster.uid == "${clusterId}"`;
+export const getEventsForCluster = async (
+  dtClient: HttpClient,
+  clusterId: string,
+  kubernetesEntityId: string,
+  eventType: string,
+) => {
+  let dql = 'fetch events';
 
-  if (!clusterId) {
-    // if no clusterId is provided, we need to fetch all events
-    dql = `fetch events | filter isNotNull(k8s.cluster.uid)`;
+  if (!clusterId && !kubernetesEntityId) {
+    // If no clusterId or kubernetesEntityId is provided, return all kubernetes related events
+    dql += ` | filter isNotNull(k8s.cluster.uid)`;
+  } else if (clusterId || kubernetesEntityId) {
+    // filter by clusterId or kubernetesEntityId if provided
+    dql += `| filter k8s.cluster.uid == "${clusterId}" or dt.entity.kubernetes_cluster == "${kubernetesEntityId}"`;
   }
+
+  // filter by eventType if provided
+  if (eventType) {
+    dql += ` | filter eventType == "${eventType}"`;
+  }
+
+  // sort by timestamp
+  dql += ' | sort timestamp desc';
 
   return executeDql(dtClient, { query: dql });
 };


### PR DESCRIPTION
Also fixed the parameter `clusterId` and the respective DQL filter to use the Dynatrace Entity ID for Kubernetes Clusters (else, you wouldn't find the cluster events).

<img width="948" height="772" alt="image" src="https://github.com/user-attachments/assets/aae523d2-c397-443c-9fa7-95fecd6a8949" />
