### PR TITLE
chore: Fixing publishing to anthropic mcp registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       # From https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/latest/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       # Login to GitHub - apparently this works out of the box with GH Workflows
       - name: Login to MCP Registry

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol server for Dynatrace - access logs, events, metrics from Dynatrace via MCP.",
   "status": "active",
@@ -10,25 +10,25 @@
   "version": "0.7.0",
   "packages": [
     {
-      "registry_type": "npm",
-      "registry_base_url": "https://registry.npmjs.org",
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
       "version": "0.7.0",
-      "runtime_hint": "npx",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "description": "Your Dynatrace Platform Token",
-          "is_required": true,
+          "isRequired": true,
           "format": "string",
-          "is_secret": true,
+          "isSecret": true,
           "name": "DT_PLATFORM_TOKEN"
         },
         {
           "description": "The URL of your Dynatrace environment (e.g. 'https://abc12345.apps.dynatrace.com')",
-          "is_required": true,
+          "isRequired": true,
           "format": "string",
           "name": "DT_ENVIRONMENT"
         }


### PR DESCRIPTION
* GH Actions changes from: https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md
* server.json changes from: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md#server-json-schema-changelog