### PR TITLE
patch: Respond with a proper JSON RPC error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1193,7 +1193,8 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
           body = JSON.parse(rawBody);
         } catch (error) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
+          // Respond with a JSON-RPC Parse error
+          res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
           return;
         }
       }


### PR DESCRIPTION
We were notified that our MCP Server does not always respodnw ith a proper JSON RPC Error Message. This should fix it.

To verify:
1. Start the server via `node dist/index.js --http`
2. Use `curl -H "Accept: application/json; text/event-stream"  -H "Content-Type: application/json" -X POST http://localhost:3000 --data '{"jsonrpc": "2.0", "method": "tools/list""}'`
3. Expect `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`
