### PR TITLE
chore: fix snyk command by removing tags

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,7 +27,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
         with:
           # Fail the build on high severity vulnerabilities
-          args: --severity-threshold=high --project-tags=open-source
+          args: --severity-threshold=high
 
       - name: Run Snyk Monitor
         # Only monitor on main branch pushes and releases, not on PRs
@@ -37,4 +37,3 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
         with:
           command: monitor
-          args: --project-tags=open-source


### PR DESCRIPTION
Looks like the open-source tag is not working well, so I'm removing it from both calls
<img width="1036" height="654" alt="image" src="https://github.com/user-attachments/assets/3136731e-742e-4a29-ad7f-856d472c2f25" />
