### PR TITLE
chore: Fix husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
 npm run test:unit
 npm run prettier:fix
+
+# Update index changes caused by prettier
+git update-index --again || true


### PR DESCRIPTION
Adding the `update-index` command again, as any change done by `prettier:fix` needs to be re-commited, which is annoying.