### PR TITLE
Add OSV dependency vulnerability scanning GitHub Action

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,34 @@
+name: OSV Scanner
+
+# Scans the repository for vulnerable dependencies using Google's OSV Scanner
+# Docs: https://google.github.io/osv-scanner/github-action/
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # Every Monday at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  actions: read # required by reusable workflow to checkout and run
+  contents: read # minimal read access
+  security-events: write # needed to upload SARIF to code scanning
+
+jobs:
+  osv-scan:
+    name: OSV Full Scan
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.2.3
+    with:
+      # Optional: override default scan arguments (defaults already recursive). Keep explicit for clarity.
+      scan-args: |-
+        --recursive
+        ./
+      upload-sarif: true
+      fail-on-vuln: false
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
Adds OSV dependency vulnerability scanning via GitHub Actions.

This workflow:

* Runs on push & PR to main, plus a weekly scheduled scan (Mondays 03:00 UTC)
*  Uses the official OSV Scanner Action to detect known vulnerabilities: https://google.github.io/osv-scanner/github-action/
*  Converts results to SARIF and uploads them to GitHub Code Scanning (visible under Security → Code scanning alerts)
*  Complements existing Snyk scanning for broader coverage (different advisory sources)

References:

* OSV Scanner Action docs: https://google.github.io/osv-scanner/github-action
* OSV vulnerability database: https://osv.dev

<img width="1068" height="546" alt="image" src="https://github.com/user-attachments/assets/54accbc7-edac-4dda-a74d-0be7eed58ac0" />
