### PR TITLE
patch: Remove stack trace for telemetry-init-error. Fixes #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+### Fixed
+
+- Suppress stack trace when telemetry is disabled via `DT_MCP_DISABLE_TELEMETRY=true`; now logs a concise message instead of throwing an error
+
 ### Tools
 
 - `find_entities_by_name` now uses `smartscapeNode` DQL command under the hood, and will fall back to `fetch dt.entity.${entityType}`.

--- a/src/utils/telemetry-openkit.ts
+++ b/src/utils/telemetry-openkit.ts
@@ -203,8 +203,8 @@ export function createTelemetry(): Telemetry {
   try {
     return new DynatraceMcpTelemetry();
   } catch (e) {
-    // Failed to initialize
-    console.error(e);
+    // Failed to initialize (unexpected). Log concise message without stack trace spam.
+    console.error('Dynatrace Telemetry initialization failed:', (e as Error).message);
     // fallback to NoOp Telemetry
     return new NoOpTelemetry();
   }


### PR DESCRIPTION
No more stacktrace. If initialization fails for any reason, it's not relevant for the user. A small log message is sufficient.

<img width="1395" height="176" alt="image" src="https://github.com/user-attachments/assets/ba5d6b09-0ec5-4c0e-910e-b9e7ba7907d6" />
