### PR TITLE
patch: Added query limit to execute_dql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Tools
 
 - `find_entities_by_name` now uses `smartscapeNode` DQL command under the hood, and will fall back to `fetch dt.entity.${entityType}`.
+- Added default response limiting to `execute_dql` tool with new parameters `recordLimit` (default 100) and `recordSizeLimitMB` (default 1 MB) to prevent overwhelming LLM context. These limits apply only to the returned payload, not the underlying DQL execution.
 
 ### Scopes
 


### PR DESCRIPTION
This helps to further avoid context-overload of the LLM, and to reduce query costs (in case the user uses very broad queries, like fetch all logs).
<img width="1100" height="1093" alt="image" src="https://github.com/user-attachments/assets/94474099-51a1-4796-a901-4db928d6f20a" />
