### PR TITLE
fix: Improve filtering for find_entity_by_name tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 
 - Fixed usage percentage to no longer be printed when no budget is set
+- Fixed an issue with `find_entity_by_name` tool filtering out valid entries
 
 ## 0.10.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,18 +506,16 @@ const main = async () => {
       if (result && result.records && result.records.length > 0) {
         // Filter valid entities first, to ensure we display up to maxEntitiesToDisplay entities
         const validClassicEntities = result.records.filter(
-          (entity): entity is { id: string; type: string; name: string; [key: string]: any } =>
-            !!(entity && entity.id && entity.type && entity.name),
+          (entity): entity is { id: string; [key: string]: any } =>
+            !!(entity && entity.id && entity['entity.type'] && entity['entity.name']),
         );
 
         let resp = `Found ${validClassicEntities.length} monitored entities! Displaying the first ${Math.min(maxEntitiesToDisplay, validClassicEntities.length)} entities:\n`;
 
         // iterate over dqlResponse and create a string with the problem details, but only show the top maxEntitiesToDisplay problems
         validClassicEntities.slice(0, maxEntitiesToDisplay).forEach((entity) => {
-          if (entity && entity.id) {
-            const entityType = getEntityTypeFromId(String(entity.id));
-            resp += `- Entity '${entity['entity.name']}' of entity-type '${entity['entity.type']}' has entity id '${entity.id}' and tags ${entity['tags'] ? entity['tags'] : 'none'} - DQL Filter: '| filter ${entityType} == "${entity.id}"'\n`;
-          }
+          const entityType = getEntityTypeFromId(String(entity.id));
+          resp += `- Entity '${entity['entity.name']}' of entity-type '${entity['entity.type']}' has entity id '${entity.id}' and tags ${entity['tags'] ? entity['tags'] : 'none'} - DQL Filter: '| filter ${entityType} == "${entity.id}"'\n`;
         });
 
         resp +=


### PR DESCRIPTION
we accidentally filtered out the "good" ones for the fallback.
<img width="672" height="496" alt="image" src="https://github.com/user-attachments/assets/8add618f-edb3-4284-8828-523204528099" />


Fixed:
<img width="674" height="886" alt="image" src="https://github.com/user-attachments/assets/ac20b73a-0d0c-4ee2-a896-8fb584dff927" />
