### PR TITLE
fix: don't show consumption in percentage if no budget is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Fixed usage percentage to no longer be printed when no budget is set
+
 ## 0.10.0
 
 ### Tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -669,9 +669,17 @@ const main = async () => {
 
         // Show budget status if available
         if (response.budgetState) {
-          const usagePercentage =
-            (response.budgetState.totalBytesScanned / response.budgetState.budgetLimitBytes) * 100;
-          result += ` (Session total: ${(response.budgetState.totalBytesScanned / (1000 * 1000 * 1000)).toFixed(2)} GB / ${response.budgetState.budgetLimitGB} GB budget, ${usagePercentage.toFixed(1)}% used)`;
+          const totalScannedGB = (response.budgetState.totalBytesScanned / (1000 * 1000 * 1000)).toFixed(2);
+
+          if (response.budgetState.budgetLimitGB > 0) {
+            const usagePercentage = (
+              (response.budgetState.totalBytesScanned / response.budgetState.budgetLimitBytes) *
+              100
+            ).toFixed(1);
+            result += ` (Session total: ${totalScannedGB} GB / ${response.budgetState.budgetLimitGB} GB budget, ${usagePercentage}% used)`;
+          } else {
+            result += ` (Session total: ${totalScannedGB} GB)`;
+          }
         }
         result += '\n';
 


### PR DESCRIPTION
This pull request updates how budget usage information is displayed to users. The main improvement is that the usage percentage is no longer shown when no budget is set, making the output clearer and more accurate.

User-facing improvements:

* The usage percentage is now omitted from the output when there is no budget limit set, so users will only see the total scanned GB in those cases. (`src/index.ts`)
* This change is noted in the `CHANGELOG.md` to inform users of the updated behavior.