### PR TITLE
patch: Improve URL detection for DT_ENVIRONMENT

### DIFF
--- a/src/getDynatraceEnv.test.ts
+++ b/src/getDynatraceEnv.test.ts
@@ -68,6 +68,14 @@ describe('getDynatraceEnv', () => {
     expect(() => getDynatraceEnv(env)).toThrow(/Dynatrace Platform Environment URL/);
   });
 
+  it('throws if DT_ENVIRONMENT is malformed with extra domain', () => {
+    const env = {
+      ...baseEnv,
+      DT_ENVIRONMENT: 'https://demo.dev.apps.dynatracelabs.com.example.com',
+    };
+    expect(() => getDynatraceEnv(env)).toThrow(/Dynatrace Platform Environment URL/);
+  });
+
   it('accepts DT_ENVIRONMENT with apps.dynatracelabs.com', () => {
     const env = {
       ...baseEnv,
@@ -80,6 +88,22 @@ describe('getDynatraceEnv', () => {
     const env = {
       ...baseEnv,
       DT_ENVIRONMENT: 'https://env123.apps.dynatrace.com',
+    };
+    expect(() => getDynatraceEnv(env)).not.toThrow();
+  });
+
+  it('accepts DT_ENVIRONMENT with apps.dynatrace.com with trailing slash', () => {
+    const env = {
+      ...baseEnv,
+      DT_ENVIRONMENT: 'https://env123.apps.dynatrace.com/',
+    };
+    expect(() => getDynatraceEnv(env)).not.toThrow();
+  });
+
+  it('accepts DT_ENVIRONMENT with apps.dynatracelabs.com with trailing slash', () => {
+    const env = {
+      ...baseEnv,
+      DT_ENVIRONMENT: 'https://xyz789.apps.dynatracelabs.com/',
     };
     expect(() => getDynatraceEnv(env)).not.toThrow();
   });

--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -45,9 +45,10 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
     );
   }
 
-  if (!dtEnvironment.includes('apps.dynatrace.com') && !dtEnvironment.includes('apps.dynatracelabs.com')) {
+  // Only allow certain Dynatrace specific Platform URLs (this is to avoid that users enter URLs like <enviornment-i>.live.dynatrace.com)
+  if (!/\.apps\.(dynatrace|dynatracelabs)\.com\/?$/.test(dtEnvironment)) {
     throw new Error(
-      'Please set DT_ENVIRONMENT to a valid Dynatrace Platform Environment URL (e.g., https://<environment-id>.apps.dynatrace.com)',
+      'Please set DT_ENVIRONMENT to a valid Dynatrace Platform Environment URL (e.g., https://<environment-id>.apps.dynatrace.com or https://<environment-id>.sprint.apps.dynatracelabs.com)',
     );
   }
 


### PR DESCRIPTION
Two flies, one clap:

* Improve `DT_ENVIRONMENT` url processing, such that we ensure that nobody can trick the MCP server into using a URL that ends with anything but `dynatrace.com` (or `dynatracelabs.com`)
* Improve error messages to also include `sprint.apps.dynatracelabs.com`)