### PR TITLE
feat: Change default HTTP server host to 127.0.0.1 for improved security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Breaking: Changed default HTTP server host binding from `0.0.0.0` to `127.0.0.1` for improved security
+
 ## 0.11.0
 
 - Fixed usage percentage to no longer be printed when no budget is set

--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --server -p 8080
 npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --port 3001
 
 # Run with custom host/IP (using short or long flag)
-npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 127.0.0.1
-npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http -H 192.168.0.1
+npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 127.0.0.1 # recommended for local computers
+npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 0.0.0.0 # recommended for container
+npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http -H 192.168.0.1 # recommended when sharing connection over a local network
 
 # Check version
 npx -y @dynatrace-oss/dynatrace-mcp-server@latest --version

--- a/src/index.ts
+++ b/src/index.ts
@@ -1151,7 +1151,7 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     .option('--http', 'enable HTTP server mode instead of stdio')
     .option('--server', 'enable HTTP server mode (alias for --http)')
     .option('-p, --port <number>', 'port for HTTP server', '3000')
-    .option('-H, --host <host>', 'host for HTTP server', '0.0.0.0')
+    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
     .parse();
 
   const options = program.opts();


### PR DESCRIPTION
Improve security by defaulting to 127.0.0.1.
For any specific scenarios, like containers, we would advise users to use a specific IP address like `--http 12.34.56.78` anyway.