### PR TITLE
Rename extension from 'dynatrace-mcp-server' to 'dynatrace'

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,7 @@
 {
-  "name": "dynatrace-mcp-server",
+  "name": "dynatrace",
   "version": "0.11.0",
+  "description": "Interact with the Dynatrace observability platform.",
   "mcpServers": {
     "dynatrace": {
       "command": "npx",


### PR DESCRIPTION
Gemini CLI team member here 👋 

Gemini CLI extensions can be much more than just MCP servers, for that reason we highly recommend removing mcp from their names and instead just use the product (aka dynatrace).

That way users leveraging the extension don't actually need to even know what MCP is 😄

Also the description field in the `gemini-extension.json` populates the tile card for the extension in our gallery: https://geminicli.com/extensions/

## Current

<img width="515" height="339" alt="image" src="https://github.com/user-attachments/assets/50136c13-a374-4fdc-851c-cb4887f2b9a2" />

## Proposed

<img width="507" height="345" alt="image" src="https://github.com/user-attachments/assets/7c227442-00bc-47a9-853e-296fe6480e0f" />

I also recommend adding a custom context file (`DYNATRACE.md`) with best practices for improving Dynatrace workflows and some custom commands to streamline workflows for users. This would take the extension to the next level. 🚀 