### PR TITLE
chore: Fix mcp publisher (again)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol server for Dynatrace - access logs, events, metrics from Dynatrace via MCP.",
   "status": "active",


### PR DESCRIPTION
This should fix
```
Error: publish failed: server returned status 400: {"title":"Bad Request","status":400,"detail":"Failed to publish server","errors":[{"message":"schema version https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json is not supported. Please use schema version 2025-10-17"}]}
```