### PR TITLE
feat: Added Davis Analyzers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,12 @@ Please do not install any other dependencies.
 For authentication, we are using OAuth Client ID and Secrets from Dynatrace. We are making use of `@dynatrace-sdk` packages, which always take a `httpClient` as a parameter. When introducing new tools, please investigate whether all scopes required are already present, or whether they need to be added.
 Make sure to not just update the code, but also update README.md with those required scopes.
 
+**Important:** OAuth scopes must always be kept in sync between implementation and documentation:
+
+- Implementation: `src/index.ts` defines all scopes in the `allRequiredScopes` array
+- Documentation: `README.md` section "Scopes for Authentication" lists all scopes with descriptions
+- Use the same scope names and maintain consistent descriptions
+
 ## Building and Running
 
 Try to build every change using `npm run build`, and verify that you can still start the server using `npm start`. The server should be able to run without any errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 - Fixed zod version mismatch that caused errors during parameterized tool calls.
 - Refactored environment variable handling to remove `dotenv` dependency from production code in favour of [--env-files](https://nodejs.org/docs/v24.5.0/api/environment_variables.html#env-files).
 
+### Tools
+
+- Added `list_davis_analyzers` tool to list all available Davis Analyzers including forecast, anomaly detection, and correlation analyzers
+- Added `execute_davis_analyzer` tool to execute Davis Analyzers with custom input parameters and timeframe configuration
+
+### Scopes
+
+- Added OAuth scopes `davis:analyzers:read` and `davis:analyzers:execute` to support Davis Analyzer operations
+
 ## 0.13.0
 
 ### Tools

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Depending on the features you are using, the following scopes are needed:
 - `davis-copilot:conversations:execute` - execute conversational skill (chat with Copilot)
 - `davis-copilot:nl2dql:execute` - execute Davis Copilot Natural Language (NL) to DQL skill
 - `davis-copilot:dql2nl:execute` - execute DQL to Natural Language (NL) skill
+- `davis:analyzers:read` - needed for listing and getting Davis analyzer definitions
+- `davis:analyzers:execute` - needed for executing Davis analyzers
 - `email:emails:send` - needed for `send_email` tool to send emails
 
 **Notes**:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -32,6 +32,12 @@ npm test -- integration-tests/execute-dql.integration.test.ts
 # Davis CoPilot tests
 npm test -- integration-tests/davis-copilot-explain-dql.integration.test.ts
 
+# Davis Analyzers listing tests
+npm test -- integration-tests/davis-analyzers-list.integration.test.ts
+
+# Davis Analyzers forecasting tests
+npm test -- integration-tests/davis-analyzers-forecast-memory.integration.test.ts
+
 # Email tests
 npm test -- integration-tests/send-email.integration.test.ts
 ```

--- a/integration-tests/davis-analyzers-forecast-memory.integration.test.ts
+++ b/integration-tests/davis-analyzers-forecast-memory.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration test for Davis analyzers - memory forecasting
+ *
+ * Verifies the Davis analyzer execution by making actual API calls
+ * to the Dynatrace environment.
+ */
+
+import { config } from 'dotenv';
+import { createDtHttpClient } from '../src/authentication/dynatrace-clients';
+import { executeDavisAnalyzer } from '../src/capabilities/davis-analyzers';
+import { getDynatraceEnv, DynatraceEnv } from '../src/getDynatraceEnv';
+
+// Load environment variables
+config();
+
+const API_RATE_LIMIT_DELAY = 2000; // Delay in milliseconds to avoid hitting API rate limits
+
+const scopesBase = ['app-engine:apps:run'];
+
+const scopesDavisAnalyzers = [
+  'davis:analyzers:read', // needed for listing and getting Davis analyzer definitions
+  'davis:analyzers:execute', // needed for executing Davis analyzers
+];
+
+describe('Davis Analyzers - Memory Forecasting Integration Tests', () => {
+  let dynatraceEnv: DynatraceEnv;
+
+  // Setup that runs once before all tests
+  beforeAll(async () => {
+    try {
+      dynatraceEnv = getDynatraceEnv();
+      console.log(`Testing against environment: ${dynatraceEnv.dtEnvironment}`);
+    } catch (err) {
+      throw new Error(`Environment configuration error: ${(err as Error).message}`);
+    }
+  });
+
+  afterEach(async () => {
+    // Add delay to avoid hitting API rate limits
+    await new Promise((resolve) => setTimeout(resolve, API_RATE_LIMIT_DELAY));
+  });
+
+  // Helper function to create HTTP client for Davis analyzers
+  const createHttpClient = async () => {
+    const { oauthClientId, oauthClientSecret, dtEnvironment, dtPlatformToken } = dynatraceEnv;
+
+    return await createDtHttpClient(
+      dtEnvironment,
+      scopesBase.concat(scopesDavisAnalyzers),
+      oauthClientId,
+      oauthClientSecret,
+      dtPlatformToken,
+    );
+  };
+
+  test('should execute forecast analyzer for memory usage', async () => {
+    const dtClient = await createHttpClient();
+
+    // Use a DQL query to forecast process memory usage
+    const forecastInput = {
+      timeSeriesData: 'timeseries avg(dt.process.memory.usage)',
+      forecastHorizon: 12,
+    };
+
+    const result = await executeDavisAnalyzer(dtClient, 'dt.statistics.GenericForecastAnalyzer', forecastInput);
+
+    expect(result).toBeDefined();
+    expect(result.analysisStatus).toBe('OK');
+
+    // Check forecast quality assessment
+    expect(result.forecastQualityAssessment).toBeDefined();
+    expect(['VALID', 'INVALID', 'UNKNOWN']).toContain(result.forecastQualityAssessment);
+
+    // Check that we have forecast data
+    expect(result.timeSeriesDataWithPredictions).toBeDefined();
+    expect(result.timeSeriesDataWithPredictions.records).toBeDefined();
+    expect(Array.isArray(result.timeSeriesDataWithPredictions.records)).toBe(true);
+
+    if (result.timeSeriesDataWithPredictions.records.length > 0) {
+      const forecastRecord = result.timeSeriesDataWithPredictions.records[0];
+
+      // Check that forecast contains the expected fields
+      expect(forecastRecord['dt.davis.forecast:point']).toBeDefined();
+      expect(forecastRecord['dt.davis.forecast:lower']).toBeDefined();
+      expect(forecastRecord['dt.davis.forecast:upper']).toBeDefined();
+
+      // Check that forecast arrays have the expected length (forecastHorizon)
+      expect(Array.isArray(forecastRecord['dt.davis.forecast:point'])).toBe(true);
+      expect(forecastRecord['dt.davis.forecast:point'].length).toBe(12);
+
+      expect(Array.isArray(forecastRecord['dt.davis.forecast:lower'])).toBe(true);
+      expect(forecastRecord['dt.davis.forecast:lower'].length).toBe(12);
+
+      expect(Array.isArray(forecastRecord['dt.davis.forecast:upper'])).toBe(true);
+      expect(forecastRecord['dt.davis.forecast:upper'].length).toBe(12);
+
+      // Check that forecast values are reasonable (should be numbers)
+      forecastRecord['dt.davis.forecast:point'].forEach((value: any) => {
+        expect(typeof value).toBe('number');
+        expect(value).toBeGreaterThanOrEqual(0);
+      });
+    }
+  });
+
+  test('should handle invalid analyzer name gracefully', async () => {
+    const dtClient = await createHttpClient();
+
+    const invalidAnalyzerName = 'dt.nonexistent.analyzer';
+    const forecastInput = {
+      timeSeriesData: 'timeseries avg(dt.process.memory.usage)',
+      forecastHorizon: 1,
+    };
+
+    await expect(executeDavisAnalyzer(dtClient, invalidAnalyzerName, forecastInput)).rejects.toThrow();
+  });
+
+  test('should handle invalid time series data gracefully', async () => {
+    const dtClient = await createHttpClient();
+
+    const invalidInput = {
+      timeSeriesData: 'invalid dql query syntax {{{',
+      forecastHorizon: 1,
+    };
+
+    const result = await executeDavisAnalyzer(dtClient, 'dt.statistics.GenericForecastAnalyzer', invalidInput);
+
+    // The analyzer might still return a result but with FAILED status
+    expect(result).toBeDefined();
+    expect(result.analysisStatus).toBeDefined();
+
+    // If it fails, it should indicate the failure
+    if (result.analysisStatus !== 'OK') {
+      expect(result.analysisStatus).toBe('FAILED');
+    }
+  });
+});

--- a/integration-tests/davis-analyzers-list.integration.test.ts
+++ b/integration-tests/davis-analyzers-list.integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration test for Davis analyzers - listing functionality
+ *
+ * Verifies the Davis analyzer listing by making actual API calls
+ * to the Dynatrace environment.
+ */
+
+import { config } from 'dotenv';
+import { createDtHttpClient } from '../src/authentication/dynatrace-clients';
+import { listDavisAnalyzers, DavisAnalyzer } from '../src/capabilities/davis-analyzers';
+import { getDynatraceEnv, DynatraceEnv } from '../src/getDynatraceEnv';
+
+// Load environment variables
+config();
+
+const API_RATE_LIMIT_DELAY = 1000; // Delay in milliseconds to avoid hitting API rate limits
+
+const scopesBase = [
+  'app-engine:apps:run', // needed for environmentInformationClient
+];
+
+const scopesDavisAnalyzers = [
+  'davis:analyzers:read', // needed for listing and getting Davis analyzer definitions
+];
+
+describe('Davis Analyzers - Listing Integration Tests', () => {
+  let dynatraceEnv: DynatraceEnv;
+
+  beforeAll(async () => {
+    try {
+      dynatraceEnv = getDynatraceEnv();
+      console.log(`Testing against environment: ${dynatraceEnv.dtEnvironment}`);
+    } catch (err) {
+      throw new Error(`Environment configuration error: ${(err as Error).message}`);
+    }
+  });
+
+  afterEach(async () => {
+    // Add delay to avoid hitting API rate limits
+    await new Promise((resolve) => setTimeout(resolve, API_RATE_LIMIT_DELAY));
+  });
+
+  // Helper function to create HTTP client for Davis analyzers
+  const createHttpClient = async () => {
+    const { oauthClientId, oauthClientSecret, dtEnvironment, dtPlatformToken } = dynatraceEnv;
+
+    return await createDtHttpClient(
+      dtEnvironment,
+      scopesBase.concat(scopesDavisAnalyzers),
+      oauthClientId,
+      oauthClientSecret,
+      dtPlatformToken,
+    );
+  };
+
+  test('should list available Davis analyzers', async () => {
+    const dtClient = await createHttpClient();
+
+    const analyzers = await listDavisAnalyzers(dtClient);
+
+    expect(analyzers).toBeDefined();
+    expect(Array.isArray(analyzers)).toBe(true);
+    expect(analyzers.length).toBeGreaterThan(0);
+
+    // Check that we have the forecast analyzer
+    const forecastAnalyzer = analyzers.find(
+      (analyzer: DavisAnalyzer) => analyzer.name === 'dt.statistics.GenericForecastAnalyzer',
+    );
+    expect(forecastAnalyzer).toBeDefined();
+    expect(forecastAnalyzer?.displayName).toContain('Forecast');
+    expect(forecastAnalyzer?.description).toContain('Forecast');
+
+    // Check that all analyzers have required fields
+    analyzers.forEach((analyzer: DavisAnalyzer) => {
+      expect(analyzer.name).toBeDefined();
+      expect(typeof analyzer.name).toBe('string');
+      expect(analyzer.displayName).toBeDefined();
+      expect(typeof analyzer.displayName).toBe('string');
+      expect(analyzer.description).toBeDefined();
+      expect(typeof analyzer.description).toBe('string');
+    });
+
+    // Check that we have anomaly detection analyzers
+    const anomalyAnalyzers = analyzers.filter(
+      (analyzer: DavisAnalyzer) =>
+        analyzer.name.includes('anomaly_detection') || analyzer.description.toLowerCase().includes('anomaly'),
+    );
+    expect(anomalyAnalyzers.length).toBeGreaterThan(0);
+
+    console.log(
+      `Found ${analyzers.length} Davis analyzers:`,
+      analyzers.map((a) => `${a.name} - ${a.displayName}`),
+    );
+  });
+
+  test('should return analyzers with proper structure', async () => {
+    const dtClient = await createHttpClient();
+
+    const analyzers = await listDavisAnalyzers(dtClient);
+
+    expect(analyzers).toBeDefined();
+    expect(Array.isArray(analyzers)).toBe(true);
+
+    if (analyzers.length > 0) {
+      const firstAnalyzer = analyzers[0];
+
+      // Check the structure of the analyzer object
+      expect(firstAnalyzer).toHaveProperty('name');
+      expect(firstAnalyzer).toHaveProperty('displayName');
+      expect(firstAnalyzer).toHaveProperty('description');
+
+      // Check optional fields
+      expect(firstAnalyzer.type === undefined || typeof firstAnalyzer.type === 'string').toBe(true);
+      expect(firstAnalyzer.category === undefined || typeof firstAnalyzer.category === 'string').toBe(true);
+      expect(firstAnalyzer.labels === undefined || Array.isArray(firstAnalyzer.labels)).toBe(true);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-automation": "^5.3.0",
+        "@dynatrace-sdk/client-davis-analyzers": "^1.9.8",
         "@dynatrace-sdk/client-davis-copilot": "^1.0.0",
         "@dynatrace-sdk/client-platform-management-service": "^1.6.3",
         "@dynatrace-sdk/client-query": "^1.18.1",
@@ -17,7 +18,6 @@
         "@dynatrace/openkit-js": "^4.1.0",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "commander": "^14.0.0",
-        "dotenv": "^17.2.1",
         "dt-app": "^1.3.1",
         "open": "^8.4.2",
         "zod-to-json-schema": "~3.24.5"
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^22",
+        "dotenv": "^17.2.1",
         "husky": "^9.1.7",
         "jest": "^30.0.0",
         "prettier": "^3.6.2",
@@ -722,6 +723,15 @@
         "@dynatrace-sdk/http-client": "^1.3.0",
         "@dynatrace-sdk/shared-client-utils": "^1.0.1",
         "@dynatrace-sdk/shared-errors": "^1.0.0"
+      }
+    },
+    "node_modules/@dynatrace-sdk/client-davis-analyzers": {
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/@dynatrace-sdk/client-davis-analyzers/-/client-davis-analyzers-1.9.8.tgz",
+      "integrity": "sha512-M0MkWVOD7LtYoyWeQLrCoOzP8Di6SAcU1+KjuLN6RQ9ivM6NVo1tlgK30mHNAuNsAqqWo/nDHauEcXHQK2FipQ==",
+      "dependencies": {
+        "@dynatrace-sdk/http-client": "^1.3.1",
+        "@dynatrace-sdk/shared-errors": "^1.0.2"
       }
     },
     "node_modules/@dynatrace-sdk/client-davis-copilot": {
@@ -4450,6 +4460,7 @@
       "version": "17.2.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
       "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "@dynatrace-sdk/client-automation": "^5.3.0",
+    "@dynatrace-sdk/client-davis-analyzers": "^1.9.8",
     "@dynatrace-sdk/client-davis-copilot": "^1.0.0",
     "@dynatrace-sdk/client-platform-management-service": "^1.6.3",
     "@dynatrace-sdk/client-query": "^1.18.1",

--- a/src/capabilities/davis-analyzers.ts
+++ b/src/capabilities/davis-analyzers.ts
@@ -1,0 +1,90 @@
+import { HttpClient } from '@dynatrace-sdk/http-client';
+import { AnalyzersClient, AnalyzerDefinition } from '@dynatrace-sdk/client-davis-analyzers';
+
+export interface DavisAnalyzer {
+  name: string;
+  displayName: string;
+  description: string;
+  type?: string;
+  category?: string;
+  labels?: string[];
+}
+
+/**
+ * List available Davis Analyzers
+ * @returns A condensed list of Davis Analyzers (array of DavisAnalyzer objects).
+ */
+export async function listDavisAnalyzers(dtClient: HttpClient): Promise<DavisAnalyzer[]> {
+  const analyzersClient = new AnalyzersClient(dtClient);
+  const response = await analyzersClient.queryAnalyzers({});
+
+  return response.analyzers.map((analyzer: AnalyzerDefinition) => ({
+    name: analyzer.name,
+    displayName: analyzer.displayName,
+    description: analyzer.description || '',
+    type: analyzer.type,
+    category: analyzer.category?.displayName,
+    labels: analyzer.labels,
+  }));
+}
+
+/**
+ * Runs a specified Davis Analyzer with given input parameters and returns the result.
+ * @returns The result of the analyzer execution.
+ */
+export async function executeDavisAnalyzer(
+  dtClient: HttpClient,
+  analyzerName: string,
+  input: Record<string, any>,
+): Promise<any> {
+  const analyzersClient = new AnalyzersClient(dtClient);
+  const response = await analyzersClient.executeAnalyzer({
+    analyzerName,
+    body: {
+      ...input,
+      generalParameters: {
+        timeframe: {
+          startTime: 'now-1h',
+          endTime: 'now',
+        },
+      },
+    },
+  });
+
+  // If there's a request token, we need to poll
+  if (response.requestToken) {
+    // Simple polling implementation
+    const maxAttempts = 10;
+    const intervalMs = 1000;
+    let attempts = 0;
+
+    while (attempts < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+
+      const pollResponse = await analyzersClient.pollAnalyzerExecution({
+        analyzerName,
+        requestToken: response.requestToken,
+      });
+
+      if (pollResponse.result?.executionStatus === 'COMPLETED') {
+        return pollResponse.result;
+      }
+
+      if (pollResponse.result?.executionStatus === 'ABORTED') {
+        throw new Error('Analyzer execution was aborted');
+      }
+
+      attempts++;
+    }
+
+    // Cancel if still running
+    await analyzersClient.cancelAnalyzerExecution({
+      analyzerName,
+      requestToken: response.requestToken,
+    });
+
+    throw new Error('Analyzer execution timed out');
+  }
+
+  return response.result;
+}


### PR DESCRIPTION
Added Davis Analyzer tools. To try it out, I did the following prompts:

> Can you fetch memory consumption metric from Dynatrace, split by service?

followed by

> can you take a look at memory consumption of <enter-service-name>? Tell me how it looked like in the past 14d

and followed by

> Can you predict how this is going to look for the next 14d?

which lead to `list_davis_analyzers` and `execute_davis_analyzer` being executed :) 

<img width="957" height="619" alt="image" src="https://github.com/user-attachments/assets/76ec5681-d21d-4e46-aeea-11595493f164" />


**Alternatively, all in one prompt**:

> Please take a look at memory consumption of the `kafka` service for the past 7 days, 14 days, and 1 month.
Furthermore, predict memory consumption for the next 7 days.

<img width="759" height="761" alt="image" src="https://github.com/user-attachments/assets/778e47bd-5757-4d41-85b7-2b995b3dbea6" />
