### PR TITLE
fix: Remove dotenv from production-code. Fixes #86

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,6 @@ Please try to follow basic TypeScript and Node.js coding conventions. We will de
 The following dependencies are allowed:
 
 - Core MCP SDK (`@modelcontextprotocol/sdk`),
-- environment utilities (`dotenv`),
 - ZOD schema validation (`zod-to-json-schema`),
 - the Dynatrace app framework (`dt-app`),
 - and `@dynatrace-sdk` packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added rate limiting to tool calls: maximum 5 calls per 20 second.
 - Fixed zod version mismatch that caused errors during parameterized tool calls.
+- Refactored environment variable handling to remove `dotenv` dependency from production code in favour of [--env-files](https://nodejs.org/docs/v24.5.0/api/environment_variables.html#env-files).
 
 ## 0.13.0
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@dynatrace/openkit-js": "^4.1.0",
     "@modelcontextprotocol/sdk": "^1.8.0",
     "commander": "^14.0.0",
-    "dotenv": "^17.2.1",
     "dt-app": "^1.3.1",
     "open": "^8.4.2",
     "zod-to-json-schema": "~3.24.5"
@@ -63,6 +62,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^22",
+    "dotenv": "^17.2.1",
     "husky": "^9.1.7",
     "jest": "^30.0.0",
     "prettier": "^3.6.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { config } from 'dotenv';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { Command } from 'commander';
 import { z, ZodRawShape, ZodTypeAny } from 'zod';
@@ -38,23 +37,6 @@ import { resetGrailBudgetTracker, getGrailBudgetTracker } from './utils/grail-bu
 import { handleClientRequestError } from './utils/dynatrace-connection-utils';
 import { configureProxyFromEnvironment } from './utils/proxy-config';
 import { listExceptions } from './capabilities/list-exceptions';
-
-// Load environment variables from .env file if available, and suppress warnings/logging to stdio
-// as it breaks MCP communication when using stdio transport
-const dotEnvOutput = config({ quiet: true });
-
-if (dotEnvOutput.error) {
-  // Only log error if it's not about missing .env file
-  if ((dotEnvOutput.error as NodeJS.ErrnoException).code !== 'ENOENT') {
-    console.error('Error loading .env file:', dotEnvOutput.error);
-    process.exit(1);
-  }
-} else {
-  // Successfully loaded .env file
-  console.error(
-    `.env file loaded successfully - loaded ${dotEnvOutput.parsed ? Object.keys(dotEnvOutput.parsed).length : 0} environment variables: ${Object.keys(dotEnvOutput.parsed || {}).join(', ')}`,
-  );
-}
 
 const DT_MCP_AUTH_CODE_FLOW_OAUTH_CLIENT_ID = 'dt0s12.local-dt-mcp-server';
 


### PR DESCRIPTION
We no longer want dotenv to be used in our production code (it's fine for integration tests though). 

Note: We never documented this feature, and we never advertised it publicly. It's still a breaking change, but it's fine as we still are in major version 0.

As an alternative, users can use NodeJS builtin features like https://nodejs.org/docs/v24.5.0/api/environment_variables.html#env-files