### PR TITLE
chore: Fix markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,8 @@
 ## 0.9.0
 
 **Highlights**
-🔑 **Simplified Authentication**: Added OAuth authorization code flow. Users can now simply set `DT_ENVIRONMENT` and complete an interactive browser authentication flow.
+
+- 🔑 **Simplified Authentication**: Added OAuth authorization code flow. Users can now simply set `DT_ENVIRONMENT` and complete an interactive browser authentication flow.
 
 ### Other Changes
 
@@ -107,9 +108,10 @@
 ## 0.7.0
 
 **Highlights**
-🔒 Human approval for critical operations
-🔍 Enhanced entity discovery with automatic detection
-🛠️ Improved error handling and internal optimizations
+
+- 🔒 Human approval for critical operations
+- 🔍 Enhanced entity discovery with automatic detection
+- 🛠️ Improved error handling and internal optimizations
 
 ### Tools
 
@@ -130,10 +132,11 @@
 ## 0.6.0
 
 **Highlights**:
-💰 Grail budget tracking and cost control
-📧 Send findings via E-Mail via the Dynatrace E-Mail API
-🔧 Enhanced tool annotations for better LLM integration
-🏪 Published to official MCP Registry and GitHub MCP Registry
+
+- 💰 Grail budget tracking and cost control
+- 📧 Send findings via E-Mail via the Dynatrace E-Mail API
+- 🔧 Enhanced tool annotations for better LLM integration
+- 🏪 Published to official MCP Registry and GitHub MCP Registry
 
 ### Scopes
 
@@ -177,10 +180,11 @@
 ## 0.5.0
 
 **Highlights**:
-🚀 Davis CoPilot AI, supporting natural language to DQL
-🌐 HTTP transport support
-🔑 Platform Token authentication
-📚 Tool consolidation into `execute_dql`
+
+- 🚀 Davis CoPilot AI, supporting natural language to DQL
+- 🌐 HTTP transport support
+- 🔑 Platform Token authentication
+- 📚 Tool consolidation into `execute_dql`
 
 ### Scopes
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ For fetching just error-logs, add `| filter loglevel == "ERROR"`.
 
 ## Environment Variables
 
-> **Breaking Change in v1.0.0:** The MCP server no longer automatically loads `.env` files. To use environment variables from a `.env` file, you must now explicitly pass the `--env-file` flag when starting the server (e.g., `npx -y @dynatrace-oss/dynatrace-mcp-server --env-file .env`) or configure your MCP client to load environment variables using the native `envFile` configuration option. See the [configuration examples](#configuration) below for details.
+> **Breaking Change in v1.0.0:** The MCP server no longer automatically loads `.env` files. To use environment variables from a `.env` file, you need to configure your MCP client to load environment variables using the native `envFile` configuration option. See the [configuration examples](#configuration) below for details.
 
 - `DT_ENVIRONMENT` (**required**, string, e.g., `https://abc12345.apps.dynatrace.com`) - URL to your Dynatrace Platform (do not use Dynatrace classic URLs like `abc12345.live.dynatrace.com`)
 - `DT_PLATFORM_TOKEN` (optional, string, e.g., `dt0s16.SAMPLE.abcd1234`) - Dynatrace Platform Token


### PR DESCRIPTION
Fixed markdown in changelog, and fixed a misleading information in README about `--env-file` (which is only available in `node`, but not in `npx`).