### PR TITLE
chore: Migrate to OpenTelemetry BizEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Removed `dt-app` dependency to reduce package size and dependency complexity, implementing a lightweight SSO URL discovery mechanism
 - Added support for `DT_SSO_URL` environment variable to allow custom SSO URL configuration for managed or special Dynatrace environments
+- Migrated telemetry implementation from OpenKit Actions to Business Events (BizEvents) for better data accessibility via Grail, simplifying the telemetry architecture while maintaining all tracking capabilities
+- Telemetry events are now sent with structured event types: `com.dynatrace-oss.mcp.server-start`, `com.dynatrace-oss.mcp.client-initialization`, `com.dynatrace-oss.mcp.tool-usage`, and `com.dynatrace-oss.mcp.error`, making it easier to query and analyze telemetry data in Grail
+- Added client initialization tracking to capture which MCP client (e.g., VS Code, Claude Desktop, Cursor) connects to the server, enabling better understanding of client usage patterns
 
 ## 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -438,11 +438,20 @@ Grail has a dedicated section about permissions in the Dynatrace Docs. Please re
 
 ## Telemetry
 
-The Dynatrace MCP Server includes sending Telemetry Data via Dynatrace OpenKit to help improve the product. This includes:
+The Dynatrace MCP Server sends telemetry data using Dynatrace OpenKit BizEvents to help improve the product. This includes:
 
-- Server start events
-- Tool usage (which tools are called, success/failure, execution duration)
-- Error tracking for debugging and improvement
+- Server start events (`com.dynatrace-oss.mcp.server-start`)
+- Client initialization events (`com.dynatrace-oss.mcp.client-initialization`) - which MCP client is connecting (e.g., VS Code, Claude Desktop, Cursor)
+- Tool usage events (`com.dynatrace-oss.mcp.tool-usage`) - which tools are called, success/failure, execution duration
+- Error events (`com.dynatrace-oss.mcp.error`) - error tracking for debugging and improvement
+
+All telemetry data is sent as **Business Events** and is accessible via Grail for analysis:
+
+```dql
+fetch bizevents
+| filter startsWith(event.type, "com.dynatrace-oss.mcp")
+| sort timestamp DESC
+```
 
 **Privacy and Opt-out:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,16 @@ const main = async () => {
     },
   );
 
+  // Track client initialization when the MCP connection is fully established
+  server.server.oninitialized = () => {
+    const clientVersion = server.server.getClientVersion();
+    if (clientVersion) {
+      telemetry
+        .trackMcpClientInitialization(clientVersion.name, clientVersion.version)
+        .catch((e) => console.warn('Failed to track client initialization:', e));
+    }
+  };
+
   // Helper function to create HTTP client with current auth settings
   // This is used to provide global scopes for auth code flow
   const createAuthenticatedHttpClient = async (scopes: string[]) => {


### PR DESCRIPTION
With this change we can now finally query relevant data (like tool calls, errors) in Grail

<img width="1637" height="426" alt="image" src="https://github.com/user-attachments/assets/938cc651-eb0c-4735-aa89-3198d49f5dba" />