### PR TITLE
fix: add DT_ENVIRONMENT in gemini-extension as a setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ gemini extensions install https://github.com/dynatrace-oss/dynatrace-mcp
 export DT_PLATFORM_TOKEN=... # optional
 ```
 
-The command will ask for the value Dynatrace Environment. 
+The command will ask for the value Dynatrace Environment.
 
 Verify that the server is running via
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,10 +4,7 @@
   "mcpServers": {
     "dynatrace": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@dynatrace-oss/dynatrace-mcp-server@latest"
-      ]
+      "args": ["-y", "@dynatrace-oss/dynatrace-mcp-server@latest"]
     }
   },
   "settings": [


### PR DESCRIPTION
Gemini extensions [now support settings](https://developers.googleblog.com/making-gemini-cli-extensions-easier-to-use/) making it easier to take in user inputs.

Earlier, it is very easy to forget setting DT_ENVIRONMENT as the env variable making the Dynatrace extension installation fail. With Gemini extension settings, the user is prompted to set Dynatrace Environment making the experience seamless.

Screenshot showing extension installation waiting for user input for Dynatrace Environment:
<img width="1256" height="290" alt="Screenshot 2026-02-17 at 7 47 52 PM" src="https://github.com/user-attachments/assets/fb43ddbe-08e7-4bbb-8aae-8300d8fafdf0" />

Screenshot post successful installation:
<img width="1257" height="308" alt="Screenshot 2026-02-17 at 7 48 51 PM" src="https://github.com/user-attachments/assets/eeb52d00-9c2b-4348-8eed-9223ed04227d" />

