### PR TITLE
patch: fix mcp server in http mode not starting up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Fixed HTTP Mode not working (`Already connected to a transport`)
+
 ## 1.5.1
 
 - Fixed MCP App theme handling, such that the MCP host theme is applied correctly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,29 +151,6 @@ const main = async () => {
     };
   };
 
-  // Initialize Metadata for MCP Server
-  const server = new McpServer(
-    {
-      name: 'Dynatrace MCP Server',
-      version: getPackageJsonVersion(),
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
-    },
-  );
-
-  // Track client initialization when the MCP connection is fully established
-  server.server.oninitialized = () => {
-    const clientVersion = server.server.getClientVersion();
-    if (clientVersion) {
-      telemetry
-        .trackMcpClientInitialization(clientVersion.name, clientVersion.version)
-        .catch((e) => console.warn('Failed to track client initialization:', e));
-    }
-  };
-
   // Helper function to create HTTP client with current auth settings
   // This is used to provide global scopes for auth code flow
   const createAuthenticatedHttpClient = async (scopes: string[]) => {
@@ -233,1338 +210,1382 @@ const main = async () => {
   // Ready to start the server
   console.error(`Starting Dynatrace MCP Server v${getPackageJsonVersion()}...`);
 
-  /** Return type of a tool callback that supports optional `_meta` for the result. */
-  type ToolCallbackResult = string | { text: string; _meta?: Record<string, unknown> };
+  const createConfiguredServer = () => {
+    // Initialize Metadata for MCP Server
+    const server = new McpServer(
+      {
+        name: 'Dynatrace MCP Server',
+        version: getPackageJsonVersion(),
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
 
-  // Wraps a string-returning tool callback with rate limiting, telemetry, and error handling
-  const wrapToolCallback = (name: string, cb: (args: any) => Promise<ToolCallbackResult>) => {
-    return async (args: any, _extra?: any): Promise<CallToolResult> => {
-      // Capture starttime for telemetry and rate limiting
-      const startTime = Date.now();
-
-      /**
-       * Rate Limit: Max. 5 requests per 20 seconds
-       */
-      const twentySecondsAgo = startTime - 20000;
-
-      // First, remove all tool calls older than 20s
-      toolCallTimestamps = toolCallTimestamps.filter((ts) => ts > twentySecondsAgo);
-
-      // Second, check whether we have 5 or more calls in the past 20s
-      if (toolCallTimestamps.length >= 5) {
-        return {
-          content: [
-            { type: 'text', text: 'Rate limit exceeded: Maximum 5 tool calls per 20 seconds. Please try again later.' },
-          ],
-          isError: true,
-        };
+    // Track client initialization when the MCP connection is fully established
+    server.server.oninitialized = () => {
+      const clientVersion = server.server.getClientVersion();
+      if (clientVersion) {
+        telemetry
+          .trackMcpClientInitialization(clientVersion.name, clientVersion.version)
+          .catch((e) => console.warn('Failed to track client initialization:', e));
       }
+    };
 
-      // Last but not least, record this call
-      toolCallTimestamps.push(startTime);
-      /** Rate Limit End */
+    /** Return type of a tool callback that supports optional `_meta` for the result. */
+    type ToolCallbackResult = string | { text: string; _meta?: Record<string, unknown> };
 
-      // track toolcall for telemetry
-      let toolCallSuccessful = false;
+    // Wraps a string-returning tool callback with rate limiting, telemetry, and error handling
+    const wrapToolCallback = (name: string, cb: (args: any) => Promise<ToolCallbackResult>) => {
+      return async (args: any, _extra?: any): Promise<CallToolResult> => {
+        // Capture starttime for telemetry and rate limiting
+        const startTime = Date.now();
 
-      try {
-        // call the tool
-        const response = await cb(args);
-        toolCallSuccessful = true;
+        /**
+         * Rate Limit: Max. 5 requests per 20 seconds
+         */
+        const twentySecondsAgo = startTime - 20000;
 
-        // Support callbacks that return either a plain string or { text, _meta }
-        const text = typeof response === 'string' ? response : response.text;
-        const _meta = typeof response === 'string' ? undefined : response._meta;
+        // First, remove all tool calls older than 20s
+        toolCallTimestamps = toolCallTimestamps.filter((ts) => ts > twentySecondsAgo);
 
-        const result: CallToolResult = {
-          content: [{ type: 'text', text }],
-        };
-        if (_meta) {
-          result._meta = _meta;
-        }
-        return result;
-      } catch (error: any) {
-        // Track error
-        telemetry.trackError(error, `tool_${name}`).catch((e) => console.warn('Failed to track error:', e));
-
-        // check if it's an error originating from the Dynatrace SDK / API Gateway and provide an appropriate message to the user
-        if (isClientRequestError(error)) {
+        // Second, check whether we have 5 or more calls in the past 20s
+        if (toolCallTimestamps.length >= 5) {
           return {
-            content: [{ type: 'text', text: handleClientRequestError(error) }],
+            content: [
+              {
+                type: 'text',
+                text: 'Rate limit exceeded: Maximum 5 tool calls per 20 seconds. Please try again later.',
+              },
+            ],
             isError: true,
           };
         }
-        // else: We don't know what kind of error happened - best case we can log the error and provide error.message as a tool response
-        console.error(error);
-        return {
-          content: [{ type: 'text', text: `Error: ${error.message}` }],
-          isError: true,
-        };
-      } finally {
-        // Track tool usage
-        const duration = Date.now() - startTime;
-        telemetry
-          .trackMcpToolUsage(name, toolCallSuccessful, duration)
-          .catch((e) => console.warn('Failed to track tool usage:', e));
+
+        // Last but not least, record this call
+        toolCallTimestamps.push(startTime);
+        /** Rate Limit End */
+
+        // track toolcall for telemetry
+        let toolCallSuccessful = false;
+
+        try {
+          // call the tool
+          const response = await cb(args);
+          toolCallSuccessful = true;
+
+          // Support callbacks that return either a plain string or { text, _meta }
+          const text = typeof response === 'string' ? response : response.text;
+          const _meta = typeof response === 'string' ? undefined : response._meta;
+
+          const result: CallToolResult = {
+            content: [{ type: 'text', text }],
+          };
+          if (_meta) {
+            result._meta = _meta;
+          }
+          return result;
+        } catch (error: any) {
+          // Track error
+          telemetry.trackError(error, `tool_${name}`).catch((e) => console.warn('Failed to track error:', e));
+
+          // check if it's an error originating from the Dynatrace SDK / API Gateway and provide an appropriate message to the user
+          if (isClientRequestError(error)) {
+            return {
+              content: [{ type: 'text', text: handleClientRequestError(error) }],
+              isError: true,
+            };
+          }
+          // else: We don't know what kind of error happened - best case we can log the error and provide error.message as a tool response
+          console.error(error);
+          return {
+            content: [{ type: 'text', text: `Error: ${error.message}` }],
+            isError: true,
+          };
+        } finally {
+          // Track tool usage
+          const duration = Date.now() - startTime;
+          telemetry
+            .trackMcpToolUsage(name, toolCallSuccessful, duration)
+            .catch((e) => console.warn('Failed to track tool usage:', e));
+        }
+      };
+    };
+
+    // quick abstraction/wrapper to make it easier for tools to reply text instead of JSON
+    const tool = (
+      name: string,
+      title: string,
+      description: string,
+      paramsSchema: ZodRawShape,
+      annotations: ToolAnnotations,
+      cb: (args: any) => Promise<string>,
+    ) => {
+      server.registerTool(
+        name,
+        {
+          title: title,
+          description: description,
+          inputSchema: z.object(paramsSchema),
+          annotations: annotations,
+        },
+        (args: any) => wrapToolCallback(name, cb)(args),
+      );
+    };
+
+    /**
+     * Helper function to request human approval for potentially sensitive operations
+     * @param operation - Description of the operation requiring approval
+     * @returns Promise<boolean> - true if approved, false if declined or cancelled
+     */
+    const requestHumanApproval = async (operation: string): Promise<boolean> => {
+      try {
+        const result = await server.server.elicitInput({
+          message: `Please review: ${operation}`,
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              approval: {
+                type: 'boolean',
+                title: 'Approve this operation?',
+                description: 'Select true to approve this operation, or false to decline.',
+                default: false,
+              },
+            },
+            required: ['approval'],
+          },
+        });
+
+        if (result.action === 'accept' && result.content?.approval === true) {
+          return true;
+        }
+
+        return false;
+      } catch (error) {
+        console.error('Failed to elicit human approval:', error);
+        return false; // Default to deny if elicitation fails
       }
     };
-  };
 
-  // quick abstraction/wrapper to make it easier for tools to reply text instead of JSON
-  const tool = (
-    name: string,
-    title: string,
-    description: string,
-    paramsSchema: ZodRawShape,
-    annotations: ToolAnnotations,
-    cb: (args: any) => Promise<string>,
-  ) => {
-    server.registerTool(
-      name,
+    /** Tool Definitions below */
+
+    tool(
+      'get_environment_info',
+      'Get Environment Info',
+      'Get information about the connected Dynatrace Environment (Tenant) and verify the connection and authentication.',
+      {},
       {
-        title: title,
-        description: description,
-        inputSchema: z.object(paramsSchema),
-        annotations: annotations,
+        readOnlyHint: true,
       },
-      (args: any) => wrapToolCallback(name, cb)(args),
+      async ({}) => {
+        // create an oauth-client
+        const dtClient = await createAuthenticatedHttpClient(scopesBase);
+        const environmentInformationClient = new EnvironmentInformationClient(dtClient);
+
+        const environmentInfo = await environmentInformationClient.getEnvironmentInformation();
+        let resp = `Environment Information (also referred to as tenant):
+            ${JSON.stringify(environmentInfo)}\n`;
+
+        resp += `You can reach it via ${dtEnvironment}\n`;
+
+        return resp;
+      },
     );
-  };
 
-  /**
-   * Helper function to request human approval for potentially sensitive operations
-   * @param operation - Description of the operation requiring approval
-   * @returns Promise<boolean> - true if approved, false if declined or cancelled
-   */
-  const requestHumanApproval = async (operation: string): Promise<boolean> => {
-    try {
-      const result = await server.server.elicitInput({
-        message: `Please review: ${operation}`,
-        requestedSchema: {
-          type: 'object',
-          properties: {
-            approval: {
-              type: 'boolean',
-              title: 'Approve this operation?',
-              description: 'Select true to approve this operation, or false to decline.',
-              default: false,
-            },
-          },
-          required: ['approval'],
-        },
-      });
-
-      if (result.action === 'accept' && result.content?.approval === true) {
-        return true;
-      }
-
-      return false;
-    } catch (error) {
-      console.error('Failed to elicit human approval:', error);
-      return false; // Default to deny if elicitation fails
-    }
-  };
-
-  /** Tool Definitions below */
-
-  tool(
-    'get_environment_info',
-    'Get Environment Info',
-    'Get information about the connected Dynatrace Environment (Tenant) and verify the connection and authentication.',
-    {},
-    {
-      readOnlyHint: true,
-    },
-    async ({}) => {
-      // create an oauth-client
-      const dtClient = await createAuthenticatedHttpClient(scopesBase);
-      const environmentInformationClient = new EnvironmentInformationClient(dtClient);
-
-      const environmentInfo = await environmentInformationClient.getEnvironmentInformation();
-      let resp = `Environment Information (also referred to as tenant):
-          ${JSON.stringify(environmentInfo)}\n`;
-
-      resp += `You can reach it via ${dtEnvironment}\n`;
-
-      return resp;
-    },
-  );
-
-  tool(
-    'list_vulnerabilities',
-    'List Vulnerabilities',
-    'Retrieve all active (non-muted) vulnerabilities from Dynatrace. An additional filter can be provided using DQL filter (filter for a specific entity type and id).',
-    {
-      timeframe: z
-        .string()
-        .optional()
-        .default('30d')
-        .describe(
-          'Timeframe to query vulnerabilities (e.g., "12h", "24h", "7d", "30d", "90d"). Default: "30d". Supports hours (h) and days (d).',
-        ),
-      riskScore: z
-        .number()
-        .optional()
-        .default(8.0)
-        .describe('Minimum risk score of vulnerabilities to list (default: 8.0)'),
-      additionalFilter: z
-        .string()
-        .optional()
-        .describe(
-          'Additional DQL-based filter for accessing vulnerabilities, e.g., by entity type (preferred), like \'dt.entity.<service|host|application|$type> == "<entity-id>"\', by entity name (not recommended) \'affected_entity.name contains "<entity-name>"\' , or by tags \'entity_tags == array("dt.owner:team-foobar", "tag:tag")\'. ' +
-            'You can also filter by vulnerability details like \'vulnerability.stack == "CODE_LIBRARY"\' or \'vulnerability.risk.level == "CRITICAL"\' or \'vulnerability.davis_assessment.exposure_status == "PUBLIC_NETWORK"\'',
-        ),
-      maxVulnerabilitiesToDisplay: z
-        .number()
-        .default(25)
-        .describe('Maximum number of vulnerabilities to display in the response.'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ timeframe, riskScore, additionalFilter, maxVulnerabilitiesToDisplay }) => {
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat(
-          'storage:events:read',
-          'storage:buckets:read',
-          'storage:security.events:read', // Read Security events from Grail
-        ),
-      );
-      const result = await listVulnerabilities(dtClient, additionalFilter, riskScore, timeframe);
-      if (!result || result.length === 0) {
-        return `No vulnerabilities found in the last ${timeframe}`;
-      }
-      let resp = `Found ${result.length} vulnerabilities in the last ${timeframe}! Displaying the top ${maxVulnerabilitiesToDisplay} vulnerabilities:\n`;
-      result.slice(0, maxVulnerabilitiesToDisplay).forEach((vulnerability) => {
-        resp += `\n* ${vulnerability}`;
-      });
-
-      resp +=
-        `\nNext Steps:` +
-        `\n1. For specific vulnerabilities, first always fetch more details using the "execute_dql" tool and the following query:
-          "fetch security.events, from: now()-${timeframe}, to: now()
-            | filter event.provider=="Dynatrace"
-                    AND event.type=="VULNERABILITY_STATE_REPORT_EVENT"
-                    AND event.level=="ENTITY"
-            | filter vulnerability.id == "<vulnerability-id>"
-            | dedup {vulnerability.display_id, affected_entity.id}, sort:{timestamp desc}
-
-            | fields vulnerability.external_id, vulnerability.display_id, vulnerability.external_url, vulnerability.cvss.vector, vulnerability.type, vulnerability.risk.score,
-                    vulnerability.stack, vulnerability.remediation.description, vulnerability.parent.davis_assessment.score,
-                    affected_entity.name, affected_entity.affected_processes.names, affected_entity.vulnerable_functions,
-                    related_entities.databases.count, related_entities.databases.ids, related_entities.hosts.ids, related_entities.hosts.names, related_entities.kubernetes_clusters.names, related_entities.kubernetes_workloads.count, related_entities.services.count,
-                    // is it muted?
-                    vulnerability.resolution.status, vulnerability.parent.mute.status, vulnerability.mute.status,
-                    // specific description and code
-                    vulnerability.description, vulnerability.technology, vulnerability.code_location.name,
-                    // entrypoints (pure paths etc...)
-                    entry_points.entry_point_jsons"` +
-        `\nThis will give you more details about the vulnerability, including the affected entity, risk score, code-level insights, and remediation actions. Please use this information.` +
-        `\n2. For a high-level overview, you can leverage the "chat_with_davis_copilot" tool and provide \`vulnerability.id\` as context.` +
-        `\n3. Last but not least, tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.security.vulnerabilities/vulnerabilities/<vulnerability-id> for full details.`;
-
-      return resp;
-    },
-  );
-
-  tool(
-    'list_problems',
-    'List Problems',
-    'List all problems (based on "fetch dt.davis.problems") known on Dynatrace, sorted by their recency.',
-    {
-      timeframe: z
-        .string()
-        .optional()
-        .default('24h')
-        .describe(
-          'Timeframe to query problems (e.g., "12h", "24h", "7d", "30d"). Default: "24h". Supports hours (h) and days (d).',
-        ),
-      status: z
-        .enum(['ACTIVE', 'CLOSED', 'ALL'])
-        .optional()
-        .default('ALL')
-        .describe(
-          'Fitler problems by their status. "ACTIVE": only active problems (those without an end time set), "CLOSED": only closed problems (those with an end time set), "ALL": active and closed problems (default)',
-        ),
-      additionalFilter: z
-        .string()
-        .optional()
-        .describe(
-          'Additional DQL filter for dt.davis.problems - filter by entity type (preferred), like \'dt.entity.<service|host|application|$type> == "<entity-id>"\', or by entity tags \'entity_tags == array("dt.owner:team-foobar", "tag:tag")\'',
-        ),
-      maxProblemsToDisplay: z
-        .number()
-        .min(1)
-        .max(5000)
-        .default(10)
-        .describe('Maximum number of problems to display in the response.'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ timeframe, status, additionalFilter, maxProblemsToDisplay }) => {
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat('storage:events:read', 'storage:buckets:read'),
-      );
-      // get problems (uses fetch)
-      const result = await listProblems(dtClient, additionalFilter, status, timeframe);
-      if (result && result.records && result.records.length > 0) {
-        let resp = `Found ${result.records.length} problems! Displaying the top ${maxProblemsToDisplay} problems:\n`;
-        // iterate over dqlResponse and create a string with the problem details, but only show the top maxProblemsToDisplay problems
-        result.records.slice(0, maxProblemsToDisplay).forEach((problem) => {
-          if (problem) {
-            resp += `Problem ${problem['display_id']} (please refer to this problem with \`problemId\` or \`event.id\` ${problem['problem_id']}))
-                  with event.status ${problem['event.status']}, event.category ${problem['event.category']}: ${problem['event.name']} -
-                  affects ${problem['affected_users_count']} users and ${problem['affected_entity_count']} entities for a duration of ${problem['duration']}s\n`;
-          }
-        });
-
-        resp +=
-          `\nNext Steps:` +
-          `\n1. Use "execute_dql" tool with the following query to get more details about a specific problem:
-          "fetch dt.davis.problems, from: now()-${timeframe}, to: now() | filter event.id == \"<problem-id>\" | fields event.description, event.status, event.category, event.start, event.end,
-            root_cause_entity_id, root_cause_entity_name, duration, affected_entities_count,
-            event_count, affected_users_count, problem_id, dt.davis.mute.status, dt.davis.mute.user,
-            entity_tags, labels.alerting_profile, maintenance.is_under_maintenance,
-            aws.account.id, azure.resource.group, azure.subscription, cloud.provider, cloud.region,
-            dt.cost.costcenter, dt.cost.product, dt.host_group.id, dt.security_context, gcp.project.id,
-            host.name, k8s.cluster.name, k8s.cluster.uid, k8s.container.name, k8s.namespace.name, k8s.node.name, k8s.pod.name, k8s.service.name, k8s.workload.kind, k8s.workload.name"` +
-          `\n2. Use "chat_with_davis_copilot" tool and provide \`problemId\` along with all details from step 1 as context, to get insights about a specific problem via Davis Copilot (e.g., provide actionable steps to solve problem P-<problem-id>).` +
-          `\n3. Tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.davis.problems/problem/<problem-id> for more details.`;
-
-        return resp;
-      } else {
-        return 'No problems found';
-      }
-    },
-  );
-
-  tool(
-    'find_entity_by_name',
-    'Find Entity By Name',
-    'Find the entityId and type of a monitored entity (service, host, process-group, application, kubernetes-node, custom-app, ...) within the topology on Dynatrace, based on the name of the entity. Run this before querying data like logs, metrics, problems, events. If no entity name is known, make an educated guess with common identifiers like package.json `id`/`name`, helm chart names, kubernetes manifest names, and alike.',
-    {
-      entityNames: z
-        .array(z.string())
-        .describe(
-          'Names of the entities to search for - try with one name at first (identifiers like package.json id), and only try with multiple names if the first search was unsuccessful',
-        ),
-      maxEntitiesToDisplay: z.number().default(10).describe('Maximum number of entities to display in the response.'),
-      extendedSearch: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe('Set this to true if you want a comprehensive search over all available entity types.'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ entityNames, maxEntitiesToDisplay, extendedSearch }) => {
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat('storage:entities:read', 'storage:smartscape:read'),
-      );
-
-      const smartscapeResult = await findMonitoredEntityViaSmartscapeByName(dtClient, entityNames);
-
-      if (smartscapeResult && smartscapeResult.records && smartscapeResult.records.length > 0) {
-        // Filter valid entities first, to ensure we display up to maxEntitiesToDisplay entities
-        const validSmartscapeEntities = smartscapeResult.records.filter(
-          (entity): entity is { id: string; type: string; name: string; [key: string]: any } =>
-            !!(entity && entity.id && entity.type && entity.name),
-        );
-
-        let resp = `Found ${validSmartscapeEntities.length} monitored entities via Smartscape! Displaying the first ${Math.min(maxEntitiesToDisplay, validSmartscapeEntities.length)} valid entities:\n`;
-
-        validSmartscapeEntities.slice(0, maxEntitiesToDisplay).forEach((entity) => {
-          resp += `- Entity '${entity.name}' of entity-type '${entity.type}' has entity id '${entity.id}' and tags ${entity['tags'] ? JSON.stringify(entity['tags']) : 'none'} - DQL Filter: '| filter dt.smartscape.${String(entity.type).toLowerCase()} == toSmartscapeId("${entity.id}")'\n`;
-        });
-
-        resp +=
-          '\n\n**Next Steps:**\n' +
-          '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statement: "smartscapeNodes \"<entity-type>\" | filter id == <entity-id>"\n' +
-          '2. Perform a sanity check that found entities are actually the ones you are looking for, by comparing name and by type (hosts vs. containers vs. apps vs. functions) and technology (Java, TypeScript, .NET) with what is available in the local source code repo.\n' +
-          '3. Find and investigate available metrics for relevant entities, by using the `execute_dql` tool with the following DQL statement: "fetch metric.series | filter dt.smartscape.<entity-type> == toSmartscapeId(<entity-id>) | limit 20"\n' +
-          '4. Find out whether any problems exist for this entity using the `list_problems` or `list_vulnerabilities` tool, and the provided DQL-Filter\n' +
-          '5. Explore dependency & relationships with: "smartscapeEdges \"*\" | filter source_id == <entity-id> or target_id == <entity-id>" to list inbound/outbound edges (depends_on, dependency_of, owned_by, part_of) for graph context\n';
-
-        return resp;
-      }
-
-      // If no result from Smartscape, try the classic entities API
-      const result = await findMonitoredEntitiesByName(dtClient, entityNames, extendedSearch);
-
-      if (result && result.records && result.records.length > 0) {
-        // Filter valid entities first, to ensure we display up to maxEntitiesToDisplay entities
-        const validClassicEntities = result.records.filter(
-          (entity): entity is { id: string; [key: string]: any } =>
-            !!(entity && entity.id && entity['entity.type'] && entity['entity.name']),
-        );
-
-        let resp = `Found ${validClassicEntities.length} monitored entities! Displaying the first ${Math.min(maxEntitiesToDisplay, validClassicEntities.length)} entities:\n`;
-
-        // iterate over dqlResponse and create a string with the problem details, but only show the top maxEntitiesToDisplay problems
-        validClassicEntities.slice(0, maxEntitiesToDisplay).forEach((entity) => {
-          const entityType = getEntityTypeFromId(String(entity.id));
-          resp += `- Entity '${entity['entity.name']}' of entity-type '${entity['entity.type']}' has entity id '${entity.id}' and tags ${entity['tags'] ? entity['tags'] : 'none'} - DQL Filter: '| filter ${entityType} == "${entity.id}"'\n`;
-        });
-
-        resp +=
-          '\n\n**Next Steps:**\n' +
-          '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statements: "describe(dt.entity.<entity-type>)", and "fetch dt.entity.<entity-type> | filter id == <entity-id> | fieldsAdd <field-1>, <field-2>, ..."\n' +
-          '2. Perform a sanity check that found entities are actually the ones you are looking for, by comparing name and by type (hosts vs. containers vs. apps vs. functions) and technology (Java, TypeScript, .NET) with what is available in the local source code repo.\n' +
-          '3. Find and investigate available metrics for relevant entities, by using the `execute_dql` tool with the following DQL statement: "fetch metric.series | filter dt.entity.<entity-type> == <entity-id> | limit 20"\n' +
-          '4. Find out whether any problems exist for this entity using the `list_problems` or `list_vulnerabilities` tool, and the provided DQL-Filter\n';
-
-        return resp;
-      } else {
-        return 'No monitored entity found with the specified name. Try to broaden your search term or check for typos.';
-      }
-    },
-  );
-
-  tool(
-    'send_slack_message',
-    'Send Slack Message',
-    'Sends a Slack message to a dedicated Slack Channel via Slack Connector on Dynatrace',
-    {
-      channel: z.string(),
-      message: z
-        .string()
-        .describe(
-          'Slack markdown supported. Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
-        ),
-    },
-    {
-      // not read-only, not open-world, not destructive
-      readOnlyHint: false,
-    },
-    async ({ channel, message }) => {
-      // Request human approval before sending the message
-      const approved = await requestHumanApproval(`Send information via Slack to ${channel}`);
-
-      if (!approved) {
-        return 'Operation cancelled: Human approval was not granted for sending this Slack message.';
-      }
-
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('app-settings:objects:read'));
-      const response = await sendSlackMessage(dtClient, slackConnectionId, channel, message);
-
-      return `Message sent to Slack channel: ${JSON.stringify(response)}`;
-    },
-  );
-
-  tool(
-    'verify_dql',
-    'Verify DQL',
-    'Syntactically verify a Dynatrace Query Language (DQL) statement on Dynatrace GRAIL before executing it. Recommended for generated DQL statements. Skip for statements created by `generate_dql_from_natural_language` tool, as well as from documentation.',
-    {
-      dqlStatement: z.string(),
-    },
-    {
-      readOnlyHint: true,
-      idempotentHint: true, // same input always yields same output
-    },
-    async ({ dqlStatement }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase);
-      const response = await verifyDqlStatement(dtClient, dqlStatement);
-
-      let resp = 'DQL Statement Verification:\n';
-
-      if (response.notifications && response.notifications.length > 0) {
-        resp += `Please consider the following notifications for adapting the your DQL statement:\n`;
-        response.notifications.forEach((notification) => {
-          resp += `* ${notification.severity}: ${notification.message}\n`;
-        });
-      }
-
-      if (response.valid) {
-        resp += `The DQL statement is valid - you can use the "execute_dql" tool.\n`;
-      } else {
-        resp += `The DQL statement is invalid. Please adapt your statement. Consider using "generate_dql_from_natural_language" tool for help.\n`;
-      }
-
-      return resp;
-    },
-  );
-
-  // MCP App: Define the resource URI for the execute_dql interactive UI
-  // The ui:// scheme tells hosts this is an MCP App resource.
-  const executeDqlResourceUri = 'ui://execute-dql/execute-dql.html';
-
-  // Register the execute_dql tool with MCP App UI support.
-  registerAppTool(
-    server,
-    'execute_dql',
-    {
-      title: 'Execute DQL',
-      description:
-        'Get data like Logs, Metrics, Spans, Events, or Entity Data from Dynatrace Grail by executing a Dynatrace Query Language (DQL) statement. ' +
-        'Use the "generate_dql_from_natural_language" tool upfront to generate or refine a DQL statement based on your request. ' +
-        'To learn about possible fields available for filtering, use the query "fetch dt.semantic_dictionary.models | filter data_object == \\"logs\\"". ' +
-        'IMPORTANT: The MCP App UI will automatically render the query results as an interactive table and chart. ' +
-        'Do NOT generate Mermaid diagrams, ASCII charts, markdown tables, or any other visual representation of the data — the MCP App is solely responsible for rendering.',
-      inputSchema: {
-        dqlStatement: z
+    tool(
+      'list_vulnerabilities',
+      'List Vulnerabilities',
+      'Retrieve all active (non-muted) vulnerabilities from Dynatrace. An additional filter can be provided using DQL filter (filter for a specific entity type and id).',
+      {
+        timeframe: z
           .string()
+          .optional()
+          .default('30d')
           .describe(
-            'DQL Statement (Ex: "fetch [logs, spans, events, metric.series, ...], from: now()-4h, to: now() [| filter <some-filter>] [| summarize count(), by:{some-fields}]", or for metrics: "timeseries { avg(<metric-name>), value.A = avg(<metric-name>, scalar: true) }", or for entities via smartscape: "smartscapeNodes \\"[*, HOST, PROCESS, ...]\\" [| filter id == \\"<ENTITY-ID>\\"]"). ' +
-              'When querying data for a specific entity, call the `find_entity_by_name` tool first to get an appropriate filter like `dt.entity.service == "SERVICE-1234"` or `dt.entity.host == "HOST-1234"` to be used in the DQL statement. ',
+            'Timeframe to query vulnerabilities (e.g., "12h", "24h", "7d", "30d", "90d"). Default: "30d". Supports hours (h) and days (d).',
           ),
-        recordLimit: z.number().optional().default(100).describe('Maximum number of records to return (default: 100)'),
-        recordSizeLimitMB: z
+        riskScore: z
           .number()
           .optional()
-          .default(1)
-          .describe('Maximum size of the returned records in MB (default: 1MB)'),
+          .default(8.0)
+          .describe('Minimum risk score of vulnerabilities to list (default: 8.0)'),
+        additionalFilter: z
+          .string()
+          .optional()
+          .describe(
+            'Additional DQL-based filter for accessing vulnerabilities, e.g., by entity type (preferred), like \'dt.entity.<service|host|application|$type> == "<entity-id>"\', by entity name (not recommended) \'affected_entity.name contains "<entity-name>"\' , or by tags \'entity_tags == array("dt.owner:team-foobar", "tag:tag")\'. ' +
+              'You can also filter by vulnerability details like \'vulnerability.stack == "CODE_LIBRARY"\' or \'vulnerability.risk.level == "CRITICAL"\' or \'vulnerability.davis_assessment.exposure_status == "PUBLIC_NETWORK"\'',
+          ),
+        maxVulnerabilitiesToDisplay: z
+          .number()
+          .default(25)
+          .describe('Maximum number of vulnerabilities to display in the response.'),
       },
-      annotations: {
-        // not readonly (DQL statements may modify things), not idempotent (may change over time)
-        readOnlyHint: false,
-        idempotentHint: false,
-        // while we are not strictly talking to the open world here, the response from execute DQL could interpreted as a web-search, which often is referred to open-world
-        openWorldHint: true,
+      {
+        readOnlyHint: true,
       },
-      _meta: {
-        // MCP App
-        ui: { resourceUri: executeDqlResourceUri },
-      },
-    },
-    wrapToolCallback('execute_dql', async ({ dqlStatement, recordLimit = 100, recordSizeLimitMB = 1 }) => {
-      // Create a HTTP Client that has all storage:*:read scopes
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat(
-          'storage:buckets:read', // Read all system data stored on Grail
-          'storage:logs:read', // Read logs for reliability guardian validations
-          'storage:metrics:read', // Read metrics for reliability guardian validations
-          'storage:bizevents:read', // Read bizevents for reliability guardian validations
-          'storage:spans:read', // Read spans from Grail
-          'storage:entities:read', // Read Entities from Grail
-          'storage:events:read', // Read events from Grail
-          'storage:system:read', // Read System Data from Grail
-          'storage:user.events:read', // Read User events from Grail
-          'storage:user.sessions:read', // Read User sessions from Grail
-          'storage:security.events:read', // Read Security events from Grail
-          'storage:smartscape:read', // Read Smartscape Entities from Grail
-        ),
-      );
-      const response = await executeDql(
-        dtClient,
-        { query: dqlStatement, maxResultRecords: recordLimit, maxResultBytes: recordSizeLimitMB * 1024 * 1024 },
-        grailBudgetGB,
-      );
-
-      if (!response) {
-        return 'DQL execution failed or returned no result.';
-      }
-
-      // Build warnings array for structured metadata
-      const warnings: string[] = [];
-
-      if (response.budgetWarning) {
-        warnings.push(response.budgetWarning);
-      }
-
-      // Build human-readable text result
-      let result = `📊 **DQL Query Results**\n\n`;
-
-      // Cost and Performance Information
-      if (response.scannedRecords !== undefined) {
-        result += `- **Scanned Records:** ${response.scannedRecords.toLocaleString()}\n`;
-      }
-
-      if (response.scannedBytes !== undefined) {
-        // calculate scanned gigabytes for better readability in warnings and result text
-        const scannedGB = response.scannedBytes !== undefined ? response.scannedBytes / (1000 * 1000 * 1000) : 0;
-        result += `- **Scanned Bytes:** ${scannedGB.toFixed(2)} GB`;
-
-        // Show budget status if available
-        if (response.budgetState) {
-          const totalScannedGB = (response.budgetState.totalBytesScanned / (1000 * 1000 * 1000)).toFixed(2);
-
-          if (response.budgetState.budgetLimitGB > 0) {
-            const usagePercentage = (
-              (response.budgetState.totalBytesScanned / response.budgetState.budgetLimitBytes) *
-              100
-            ).toFixed(1);
-            result += ` (Session total: ${totalScannedGB} GB / ${response.budgetState.budgetLimitGB} GB budget, ${usagePercentage}% used)`;
-          } else {
-            result += ` (Session total: ${totalScannedGB} GB)`;
-          }
-        }
-        result += '\n';
-
-        if (scannedGB > 500) {
-          warnings.push(
-            `Very High Data Usage: This query scanned ${scannedGB.toFixed(1)} GB of data, which may impact your Dynatrace consumption. Please take measures to optimize your query, like limiting the timeframe or selecting a bucket.`,
-          );
-        } else if (scannedGB > 50) {
-          warnings.push(
-            `High Data Usage: This query scanned ${scannedGB.toFixed(2)} GB of data, which may impact your Dynatrace consumption.`,
-          );
-        }
-        // Add informational messages (not warnings) about data usage
-        else if (scannedGB > 5 && scannedGB <= 50) {
-          result += `    💡 **Moderate Data Usage:** This query scanned ${scannedGB.toFixed(2)} GB of data.\n`;
-        } else if (response.scannedBytes === 0) {
-          result += `    💡 **No Data consumed:** This query did not consume any data.\n`;
-        }
-
-        if (response.sampled) {
-          warnings.push('Sampling Used: Results may be approximate');
-        }
-
-        if (response.records.length === recordLimit) {
-          warnings.push(
-            `Record Limit Reached: The result set was limited to ${recordLimit} records. Consider changing your query with a smaller timeframe, an aggregation or a more concise filter. Alternatively, increase the recordLimit if you expect more results.`,
-          );
-        }
-      }
-
-      // Add all warnings to result
-      if (warnings.length > 0) {
-        result += '\n';
-        warnings.forEach((warning) => {
-          result += `- **⚠️ ${warning}**\n`;
-        });
-      }
-
-      result += `\n📋 **Query Results**: (${response.records?.length || 0} records) — rendered by the MCP App UI below.\n`;
-      result += `\n> ℹ️ The MCP App is rendering the results interactively. Do NOT generate Mermaid diagrams, ASCII charts, or markdown tables from this data.`;
-      if (response.records && response.records.length > 0) {
-        result += `\n\`\`\`json\n${JSON.stringify(response.records, null, 2)}\n\`\`\`\n`;
-      }
-
-      // Return structured data in _meta for MCP App UI instead of embedding in text
-      return {
-        text: result,
-        _meta: {
-          records: response.records,
-          types: response.types,
-          analysisTimeframe: response.metadata?.grail?.analysisTimeframe,
-          scannedRecords: response.scannedRecords,
-          scannedBytes: response.scannedBytes,
-          sampled: response.sampled,
-          environmentUrl: dtEnvironment,
-          budgetState: response.budgetState,
-          warnings,
-          recordLimit,
-          recordLimitReached: response.records.length === recordLimit,
-        },
-      };
-    }),
-  );
-
-  // MCP App: Register the HTML resource for the execute_dql interactive UI (MCP App)
-  registerAppResource(server, 'DQL Results Viewer', executeDqlResourceUri, {}, async () => {
-    const html = readFileSync(join(__dirname, 'ui', 'execute-dql', 'index.html'), 'utf-8');
-    return {
-      contents: [{ uri: executeDqlResourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
-    };
-  });
-
-  tool(
-    'generate_dql_from_natural_language',
-    'Generate DQL from Natural Language',
-    'Convert natural language queries to Dynatrace Query Language (DQL) using Davis CoPilot AI. You can ask for problem events, security issues, logs, metrics, spans, and custom data.',
-    {
-      text: z
-        .string()
-        .describe(
-          'Natural language description of what you want to query. Be specific and include time ranges, entities, and metrics of interest.',
-        ),
-    },
-    {
-      readOnlyHint: true,
-      idempotentHint: true,
-    },
-    async ({ text }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:nl2dql:execute'));
-
-      // Check if the nl2dql skill is available
-      const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'nl2dql');
-      if (!isAvailable) {
-        return `❌ The DQL generation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
-      }
-
-      const response = await generateDqlFromNaturalLanguage(dtClient, text);
-
-      let resp = `🔤 Natural Language to DQL:\n\n`;
-      resp += `**Query:** "${text}"\n\n`;
-      if (response.dql) {
-        // Typically, the DQL response is empty if status == FAILED
-        resp += `**Generated DQL:**\n\`\`\`\n${response.dql}\n\`\`\`\n\n`;
-      }
-      resp += `**Status:** ${response.status}\n`;
-      resp += `**Message Token:** ${response.messageToken}\n`;
-
-      if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
-        resp += `\n**Notifications:**\n`;
-        response.metadata.notifications.forEach((notification) => {
-          resp += `- ${notification.severity}: ${notification.message}\n`;
-        });
-      }
-
-      if (response.status != 'FAILED') {
-        resp += `\n💡 **Next Steps:**\n`;
-        resp += `1. Use "execute_dql" tool to run the query (you can omit running the "verify_dql" tool)\n`;
-        resp += `2. If results don't match expectations, refine your natural language description and try again\n`;
-      }
-
-      return resp;
-    },
-  );
-
-  tool(
-    'explain_dql_in_natural_language',
-    'Explain DQL in Natural Language',
-    'Explain Dynatrace Query Language (DQL) statements in natural language using Davis CoPilot AI.',
-    {
-      dql: z.string().describe('The DQL statement to explain'),
-    },
-    {
-      readOnlyHint: true,
-      idempotentHint: true,
-    },
-    async ({ dql }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:dql2nl:execute'));
-
-      // Check if the dql2nl skill is available
-      const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'dql2nl');
-      if (!isAvailable) {
-        return `❌ The DQL explanation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
-      }
-
-      const response = await explainDqlInNaturalLanguage(dtClient, dql);
-
-      let resp = `📝 DQL to Natural Language:\n\n`;
-      resp += `**DQL Query:**\n\`\`\`\n${dql}\n\`\`\`\n\n`;
-      resp += `**Summary:** ${response.summary}\n\n`;
-      resp += `**Detailed Explanation:**\n${response.explanation}\n\n`;
-      resp += `**Status:** ${response.status}\n`;
-      resp += `**Message Token:** ${response.messageToken}\n`;
-
-      if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
-        resp += `\n**Notifications:**\n`;
-        response.metadata.notifications.forEach((notification) => {
-          resp += `- ${notification.severity}: ${notification.message}\n`;
-        });
-      }
-
-      return resp;
-    },
-  );
-
-  tool(
-    'chat_with_davis_copilot',
-    'Chat with Davis Copilot',
-    'Use this tool to ask any Dynatrace related question, in case no other more specific tool is available.',
-    {
-      text: z.string().describe('Your question or request for Davis CoPilot'),
-      context: z
-        .string()
-        .optional()
-        .describe(
-          'Optional context to provide additional information (like problem details, vulnerability details, entity information)',
-        ),
-      instruction: z.string().optional().describe('Optional instruction for how to format the response'),
-    },
-    {
-      readOnlyHint: true,
-      idempotentHint: true,
-      openWorldHint: true, // web-search like characteristics
-    },
-    async ({ text, context, instruction }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:conversations:execute'));
-
-      // Check if the conversation skill is available
-      const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'conversation');
-      if (!isAvailable) {
-        return `❌ The conversation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
-      }
-
-      const conversationContext: any[] = [];
-
-      if (context) {
-        conversationContext.push({
-          type: 'supplementary',
-          value: context,
-        });
-      }
-
-      if (instruction) {
-        conversationContext.push({
-          type: 'instruction',
-          value: instruction,
-        });
-      }
-
-      const response = await chatWithDavisCopilot(dtClient, text, conversationContext);
-
-      let resp = `🤖 Davis CoPilot Response:\n\n`;
-      if (response.text) {
-        // Typically, text is empty if status is FAILED
-        resp += `**Answer:**\n${response.text}\n\n`;
-      }
-      resp += `**Status:** ${response.status}\n`;
-      resp += `**Message Token:** ${response.messageToken}\n`;
-
-      if (response.metadata?.sources && response.metadata.sources.length > 0) {
-        resp += `\n**Sources:**\n`;
-        response.metadata.sources.forEach((source) => {
-          resp += `- ${source.title || 'Untitled'}: ${source.url || 'No URL'}\n`;
-        });
-      }
-
-      if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
-        resp += `\n**Notifications:**\n`;
-        response.metadata.notifications.forEach((notification) => {
-          resp += `- ${notification.severity}: ${notification.message}\n`;
-        });
-      }
-
-      if (response.state?.conversationId) {
-        resp += `\n**Conversation ID:** ${response.state.conversationId}`;
-      }
-
-      if (response.status == 'FAILED') {
-        resp += `\n❌ **Your request was not successful**\n`;
-      }
-
-      return resp;
-    },
-  );
-
-  tool(
-    'create_workflow_for_notification',
-    'Create Workflow for Notification',
-    'Create a notification for a team based on a problem type within Workflows in Dynatrace',
-    {
-      problemType: z.string().optional(),
-      teamName: z.string().optional(),
-      channel: z.string().optional(),
-      isPrivate: z.boolean().optional().default(false),
-    },
-    {
-      // not read only, not idempotent
-      readOnlyHint: false,
-      idempotentHint: false, // creating the same workflow multiple times is possible
-    },
-    async ({ problemType, teamName, channel, isPrivate }) => {
-      // ask for human approval
-      const approved = await requestHumanApproval(
-        `Create a workflow for notifying team ${teamName} via ${channel} about ${problemType} problems`,
-      );
-
-      if (!approved) {
-        return 'Operation cancelled: Human approval was not granted for creating this workflow.';
-      }
-
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
-      );
-      const response = await createWorkflowForProblemNotification(dtClient, teamName, channel, problemType, isPrivate);
-
-      let resp = `Workflow Created: ${response?.id} with name ${response?.title}.\nYou can access the Workflow via the following link: ${dtEnvironment}/ui/apps/dynatrace.automations/workflows/${response?.id}.\nTell the user to inspect the Workflow by visiting the link.\n`;
-
-      if (response.type == 'SIMPLE') {
-        resp += `Note: This is a simple workflow. Workflow-hours will not be billed.\n`;
-      } else if (response.type == 'STANDARD') {
-        resp += `Note: This is a standard workflow. Workflow-hours will be billed.\n`;
-      }
-
-      if (isPrivate) {
-        resp += `This workflow is private and can only be accessed by the owner of the authentication credentials. In case you can not access it, you can instruct me to make the workflow public.`;
-      }
-
-      return resp;
-    },
-  );
-
-  tool(
-    'make_workflow_public',
-    'Make Workflow Public',
-    'Modify a workflow and make it publicly available to everyone on the Dynatrace Environment',
-    {
-      workflowId: z.string().optional(),
-    },
-    {
-      // not read only, but idempotent
-      readOnlyHint: false,
-      idempotentHint: true, // making the same workflow public multiple times yields the same result
-    },
-    async ({ workflowId }) => {
-      // ask for human approval
-      const approved = await requestHumanApproval(
-        `Make workflow ${workflowId} publicly available to everyone on the Dynatrace Environment`,
-      );
-
-      if (!approved) {
-        return 'Operation cancelled: Human approval was not granted for making this workflow public.';
-      }
-
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
-      );
-      const response = await updateWorkflow(dtClient, workflowId, {
-        isPrivate: false,
-      });
-
-      return `Workflow ${response.id} is now public!\nYou can access the Workflow via the following link: ${dtEnvironment}/ui/apps/dynatrace.automations/workflows/${response?.id}.\nTell the user to inspect the Workflow by visiting the link.\n`;
-    },
-  );
-
-  tool(
-    'get_kubernetes_events',
-    'Get Kubernetes Events',
-    'Get all events from a specific Kubernetes (K8s) cluster',
-    {
-      timeframe: z
-        .string()
-        .optional()
-        .default('24h')
-        .describe(
-          'Timeframe to query events (e.g., "12h", "24h", "7d", "30d"). Default: "24h". Supports hours (h) and days (d).',
-        ),
-      clusterId: z
-        .string()
-        .optional()
-        .describe(
-          `The Kubernetes Cluster Id, referred to as k8s.cluster.uid, usually seen when using "kubectl" - this is NOT the Dynatrace environment and not the Dynatrace Kubernetes Entity Id. Leave empty if you don't know the Cluster Id.`,
-        ),
-      kubernetesEntityId: z
-        .string()
-        .optional()
-        .describe(
-          `The Dynatrace Kubernetes Entity Id, referred to as dt.entity.kubernetes_cluster. Leave empty if you don't know the Entity Id, or use the "find_entity_by_name" tool to find the cluster by name.`,
-        ),
-      eventType: z
-        .enum([
-          'OMPLIANCE_FINDING',
-          'COMPLIANCE_SCAN_COMPLETED',
-          'CUSTOM_INFO',
-          'DETECTION_FINDING',
-          'ERROR_EVENT',
-          'OSI_UNEXPECTEDLY_UNAVAILABLE',
-          'PROCESS_RESTART',
-          'RESOURCE_CONTENTION_EVENT',
-          'SERVICE_CLIENT_ERROR_RATE_INCREASED',
-          'SERVICE_CLIENT_SLOWDOWN',
-          'SERVICE_ERROR_RATE_INCREASED',
-          'SERVICE_SLOWDOWN',
-          'SERVICE_UNEXPECTED_HIGH_LOAD',
-          'SERVICE_UNEXPECTED_LOW_LOAD',
-        ])
-        .optional(),
-      maxEventsToDisplay: z.number().default(10).describe('Maximum number of events to display in the response.'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ timeframe, clusterId, kubernetesEntityId, eventType, maxEventsToDisplay }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('storage:events:read'));
-      const result = await getEventsForCluster(dtClient, clusterId, kubernetesEntityId, eventType, timeframe);
-
-      if (result && result.records && result.records.length > 0) {
-        let resp = `Found ${result.records.length} events in the last ${timeframe}! Displaying the top ${maxEventsToDisplay} events:\n`;
-        // iterate over dqlResponse and create a string with the problem details, but only show the top maxEntitiesToDisplay problems
-        result.records.slice(0, maxEventsToDisplay).forEach((event) => {
-          if (event) {
-            resp += `- Event ${event['event.id']} (${event['event.type']}) on Kubernetes Entity ID ${event['dt.entity.kubernetes_cluster']} with status ${event['event.status']}: ${event['event.name']} - started at ${event['event.start']}, ended at ${event['event.end']}, duration: ${event['duration']}\n`;
-          }
-        });
-
-        resp +=
-          `\nNext Steps:` +
-          `\n1. Consider filtering by \`eventType\` to find specific events of interest.` +
-          `\n2. Use "execute_dql" tool with the following query to get more details about a specific event: "fetch events, from: now()-${timeframe}, to: now() | filter event.id == \"<event-id>\""`;
-
-        return resp;
-      }
-
-      return `No events found for the specified Kubernetes cluster in the last ${timeframe}. Try to leave clusterId and kubernetesEntityId empty to get events from all clusters, or increase the timeframe.`;
-    },
-  );
-
-  tool(
-    'reset_grail_budget',
-    'Reset Grail Budget',
-    'Reset the Grail query budget after it was exhausted, allowing new queries to be executed. This clears all tracked bytes scanned in the current session.',
-    {},
-    {
-      readOnlyHint: false, // modifies state
-      idempotentHint: true, // multiple resets yield the same result
-    },
-    async ({}) => {
-      // Reset the global tracker
-      resetGrailBudgetTracker();
-
-      // Get a fresh tracker to show the reset state
-      const freshTracker = getGrailBudgetTracker(grailBudgetGB);
-      const state = freshTracker.getState();
-
-      return `✅ **Grail Budget Reset Successfully!**
-
-Budget status after reset:
-- Total bytes scanned: ${state.totalBytesScanned} bytes (0 GB)
-- Budget limit: ${state.budgetLimitGB} GB
-- Remaining budget: ${state.budgetLimitGB} GB
-- Budget exceeded: ${state.isBudgetExceeded ? 'Yes' : 'No'}
-
-You can now execute new Grail queries (DQL, etc.) again. If this happens more often, please consider
-
-- Optimizing your queries (timeframes, bucket selection, filters)
-- Creating or optimizing bucket configurations that fit your queries (see https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-bucket-assignment for details)
-- Increasing \`DT_GRAIL_QUERY_BUDGET_GB\` in your environment configuration
-`;
-    },
-  );
-
-  tool(
-    'send_email',
-    'Send Email',
-    'Send an email using the Dynatrace Email API. The sender will be no-reply@apps.dynatrace.com. Maximum 10 recipients total across TO, CC, and BCC.',
-    {
-      toRecipients: z.array(z.string().email()).describe('Array of email addresses for TO recipients'),
-      ccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for CC recipients'),
-      bccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for BCC recipients'),
-      subject: z.string().describe('Subject line of the email'),
-      body: z
-        .string()
-        .describe(
-          'Body content of the email (plain text only). Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
-        ),
-    },
-    {
-      openWorldHint: true, // email is as close to the open-world as we can get with our system
-    },
-    async ({ toRecipients, ccRecipients, bccRecipients, subject, body }) => {
-      // Validate total recipients limit (10 max across TO, CC, and BCC)
-      const totalRecipients = toRecipients.length + (ccRecipients?.length || 0) + (bccRecipients?.length || 0);
-
-      if (totalRecipients > 10) {
-        throw new Error(
-          `Total recipients (${totalRecipients}) exceeds maximum limit of 10 across TO, CC, and BCC fields`,
+      async ({ timeframe, riskScore, additionalFilter, maxVulnerabilitiesToDisplay }) => {
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat(
+            'storage:events:read',
+            'storage:buckets:read',
+            'storage:security.events:read', // Read Security events from Grail
+          ),
         );
-      }
-
-      // Request human approval before sending the email
-      const allRecipients = [...toRecipients, ...(ccRecipients || []), ...(bccRecipients || [])];
-
-      const approved = await requestHumanApproval(`Send information via Email to ${allRecipients.join(', ')}`);
-
-      if (!approved) {
-        return 'Operation cancelled: Human approval was not granted for sending this email.';
-      }
-
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('email:emails:send'));
-
-      const emailRequest = {
-        toRecipients: { emailAddresses: toRecipients },
-        ...(ccRecipients && { ccRecipients: { emailAddresses: ccRecipients } }),
-        ...(bccRecipients && { bccRecipients: { emailAddresses: bccRecipients } }),
-        subject,
-        body: {
-          contentType: 'text/plain' as const,
-          body,
-        },
-      };
-
-      const result = await sendEmail(dtClient, emailRequest);
-
-      // Format the structured response into a user-friendly string
-      let responseMessage = `Email send request accepted. Request ID: ${result.requestId}\n`;
-      responseMessage += `Message: ${result.message}\n`;
-
-      if (result.invalidDestinations && result.invalidDestinations.length > 0) {
-        responseMessage += `Invalid destinations: ${result.invalidDestinations.join(', ')}\n`;
-      }
-
-      if (result.bouncingDestinations && result.bouncingDestinations.length > 0) {
-        responseMessage += `Bouncing destinations: ${result.bouncingDestinations.join(', ')}\n`;
-      }
-
-      if (result.complainingDestinations && result.complainingDestinations.length > 0) {
-        responseMessage += `Complaining destinations: ${result.complainingDestinations.join(', ')}\n`;
-      }
-
-      responseMessage += `\nNext Steps:\n- Delivery is asynchronous.\n- Investigate any invalid, bouncing, or complaining destinations before retrying.`;
-
-      return responseMessage;
-    },
-  );
-
-  tool(
-    'send_event',
-    'Send Event',
-    'Send a custom event to Dynatrace using the Events API v2. Use this to ingest custom events for alerting, tracking deployments, configuration changes, or any custom business events.',
-    {
-      eventType: z
-        .enum([
-          'AVAILABILITY_EVENT',
-          'CUSTOM_ALERT',
-          'CUSTOM_ANNOTATION',
-          'CUSTOM_CONFIGURATION',
-          'CUSTOM_DEPLOYMENT',
-          'CUSTOM_INFO',
-          'ERROR_EVENT',
-          'MARKED_FOR_TERMINATION',
-          'PERFORMANCE_EVENT',
-          'RESOURCE_CONTENTION_EVENT',
-        ])
-        .describe(
-          'Type of event to send. Common types: CUSTOM_INFO for general information, CUSTOM_DEPLOYMENT for deployments, CUSTOM_ALERT for alerts, ERROR_EVENT for errors.',
-        ),
-      title: z.string().describe('Title of the event (max 500 characters). Should be descriptive and concise.'),
-      entitySelector: z
-        .string()
-        .optional()
-        .describe(
-          'Entity selector to associate the event with specific Dynatrace entities. Example: "type(HOST),entityId(HOST-1234567890ABCDEF)" or "type(SERVICE),tag(environment:production)"',
-        ),
-      properties: z
-        .record(z.string(), z.string())
-        .optional()
-        .describe(
-          'Custom properties as key-value pairs to include with the event. Example: {"version": "1.2.3", "environment": "production"}',
-        ),
-      startTime: z
-        .number()
-        .optional()
-        .describe('Start timestamp of the event in UTC milliseconds. If not set, current time is used.'),
-      endTime: z
-        .number()
-        .optional()
-        .describe('End timestamp of the event in UTC milliseconds. If not set, current time is used.'),
-    },
-    {
-      readOnlyHint: false,
-      idempotentHint: false, // sending the same event multiple times creates multiple events
-      destructiveHint: true,
-    },
-    async ({ eventType, title, entitySelector, properties, startTime, endTime }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('storage:events:write'));
-
-      const result = await sendEvent(dtClient, {
-        eventType: eventType as EventIngestEventType,
-        title,
-        entitySelector,
-        properties,
-        startTime,
-        endTime,
-      });
-
-      let responseMessage = `Event sent successfully!\n`;
-      responseMessage += `Report count: ${result.reportCount}\n`;
-
-      if (result.eventIngestResults && result.eventIngestResults.length > 0) {
-        responseMessage += `\nEvent results:\n`;
-        result.eventIngestResults.forEach((eventResult, index) => {
-          responseMessage += `  ${index + 1}. Correlation ID: ${eventResult.correlationId}, Status: ${eventResult.status}\n`;
-        });
-      }
-
-      responseMessage += `\nNote: Events are processed asynchronously. Use the correlation ID to track the event if needed.`;
-
-      return responseMessage;
-    },
-  );
-
-  tool(
-    'list_exceptions',
-    'List Exceptions',
-    'List all exceptions known on Dynatrace starting with the most recent.',
-    {
-      timeframe: z
-        .string()
-        .optional()
-        .default('24h')
-        .describe(
-          'Timeframe to query problems (e.g., "12h", "24h", "7d", "30d", "30m"). Default: "24h". Supports days (d), hours (h) and minutes (m).',
-        ),
-      additionalFilter: z
-        .string()
-        .optional()
-        .describe(
-          'Additional DQL filter for user.events - filter by error id like \'error.id == "<error.id>"\', application id like \'dt.rum.application.id == "<dt.rum.application.id>"\', application entity like \'dt.rum.application.entity == "<dt.rum.application.entity>"\' or operating system name like \'os.name == "<os.name>"\'. Leave empty to get all exceptions within the timeframe.',
-        ),
-      maxExceptionsToDisplay: z
-        .number()
-        .default(10)
-        .describe('Maximum number of exceptions to display in the response.'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ timeframe, additionalFilter, maxExceptionsToDisplay }) => {
-      const dtClient = await createAuthenticatedHttpClient(
-        scopesBase.concat('storage:user.events:read', 'storage:buckets:read'),
-      );
-
-      // get exceptions (uses fetch)
-      const result = await listExceptions(dtClient, additionalFilter, timeframe, maxExceptionsToDisplay);
-      if (result && result.records && result.records.length > 0) {
-        let resp = `Found ${result.records.length} exceptions! Displaying the top ${maxExceptionsToDisplay} exceptions:\n`;
-        // iterate over dqlResponse and create a string with the exception details, but only show the top maxExceptionsToDisplay exceptions
-        result.records.slice(0, maxExceptionsToDisplay).forEach((exception) => {
-          if (exception) {
-            resp += `At start_time ${exception['start_time']} the exception with error.type ${exception['error.type']}, error.id ${exception['error.id']} and os.name ${exception['os.name']}
-                  happened for dt.rum.application.id ${exception['dt.rum.application.id']} with dt.rum.application.entity ${exception['dt.rum.application.entity']}.\n\n
-                  The exception.message is ${exception['exception.message']}\n\n\n`;
-          }
+        const result = await listVulnerabilities(dtClient, additionalFilter, riskScore, timeframe);
+        if (!result || result.length === 0) {
+          return `No vulnerabilities found in the last ${timeframe}`;
+        }
+        let resp = `Found ${result.length} vulnerabilities in the last ${timeframe}! Displaying the top ${maxVulnerabilitiesToDisplay} vulnerabilities:\n`;
+        result.slice(0, maxVulnerabilitiesToDisplay).forEach((vulnerability) => {
+          resp += `\n* ${vulnerability}`;
         });
 
         resp +=
           `\nNext Steps:` +
-          `\n1. Use "execute_dql" tool with the following query to get more details about a specific stack trace:` +
-          `\n"fetch user.events, from: now()-<timeframe>, to: now() | filter error.id == toUid(\"<error.id>\")" to get all occurrences with stack traces (exception.stack_trace) of this exception within this timeframe or use additional filters like dt.rum.application.id, dt.rum.application.entity or os.name as needed.` +
-          `\n2. Tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.error.inspector/explorer?tf=now-<timeframe>%3Bnow&perspective=impact&detailsId=<error.id>&sidebarOpen=false&expandedSections=details&tab=occurrence&group=occurrences for more details.`;
+          `\n1. For specific vulnerabilities, first always fetch more details using the "execute_dql" tool and the following query:
+            "fetch security.events, from: now()-${timeframe}, to: now()
+              | filter event.provider=="Dynatrace"
+                      AND event.type=="VULNERABILITY_STATE_REPORT_EVENT"
+                      AND event.level=="ENTITY"
+              | filter vulnerability.id == "<vulnerability-id>"
+              | dedup {vulnerability.display_id, affected_entity.id}, sort:{timestamp desc}
+
+              | fields vulnerability.external_id, vulnerability.display_id, vulnerability.external_url, vulnerability.cvss.vector, vulnerability.type, vulnerability.risk.score,
+                      vulnerability.stack, vulnerability.remediation.description, vulnerability.parent.davis_assessment.score,
+                      affected_entity.name, affected_entity.affected_processes.names, affected_entity.vulnerable_functions,
+                      related_entities.databases.count, related_entities.databases.ids, related_entities.hosts.ids, related_entities.hosts.names, related_entities.kubernetes_clusters.names, related_entities.kubernetes_workloads.count, related_entities.services.count,
+                      // is it muted?
+                      vulnerability.resolution.status, vulnerability.parent.mute.status, vulnerability.mute.status,
+                      // specific description and code
+                      vulnerability.description, vulnerability.technology, vulnerability.code_location.name,
+                      // entrypoints (pure paths etc...)
+                      entry_points.entry_point_jsons"` +
+          `\nThis will give you more details about the vulnerability, including the affected entity, risk score, code-level insights, and remediation actions. Please use this information.` +
+          `\n2. For a high-level overview, you can leverage the "chat_with_davis_copilot" tool and provide \`vulnerability.id\` as context.` +
+          `\n3. Last but not least, tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.security.vulnerabilities/vulnerabilities/<vulnerability-id> for full details.`;
 
         return resp;
-      } else {
-        return 'No exceptions found';
-      }
-    },
-  );
+      },
+    );
 
-  tool(
-    'list_davis_analyzers',
-    'List Davis Analyzers',
-    'List all available Davis Analyzers in Dynatrace (forecast, anomaly detection, correlation analyzers, and more)',
-    {},
-    {
-      readOnlyHint: true,
-    },
-    async ({}) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis:analyzers:read'));
-      const analyzers = await listDavisAnalyzers(dtClient);
+    tool(
+      'list_problems',
+      'List Problems',
+      'List all problems (based on "fetch dt.davis.problems") known on Dynatrace, sorted by their recency.',
+      {
+        timeframe: z
+          .string()
+          .optional()
+          .default('24h')
+          .describe(
+            'Timeframe to query problems (e.g., "12h", "24h", "7d", "30d"). Default: "24h". Supports hours (h) and days (d).',
+          ),
+        status: z
+          .enum(['ACTIVE', 'CLOSED', 'ALL'])
+          .optional()
+          .default('ALL')
+          .describe(
+            'Fitler problems by their status. "ACTIVE": only active problems (those without an end time set), "CLOSED": only closed problems (those with an end time set), "ALL": active and closed problems (default)',
+          ),
+        additionalFilter: z
+          .string()
+          .optional()
+          .describe(
+            'Additional DQL filter for dt.davis.problems - filter by entity type (preferred), like \'dt.entity.<service|host|application|$type> == "<entity-id>"\', or by entity tags \'entity_tags == array("dt.owner:team-foobar", "tag:tag")\'',
+          ),
+        maxProblemsToDisplay: z
+          .number()
+          .min(1)
+          .max(5000)
+          .default(10)
+          .describe('Maximum number of problems to display in the response.'),
+      },
+      {
+        readOnlyHint: true,
+      },
+      async ({ timeframe, status, additionalFilter, maxProblemsToDisplay }) => {
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat('storage:events:read', 'storage:buckets:read'),
+        );
+        // get problems (uses fetch)
+        const result = await listProblems(dtClient, additionalFilter, status, timeframe);
+        if (result && result.records && result.records.length > 0) {
+          let resp = `Found ${result.records.length} problems! Displaying the top ${maxProblemsToDisplay} problems:\n`;
+          // iterate over dqlResponse and create a string with the problem details, but only show the top maxProblemsToDisplay problems
+          result.records.slice(0, maxProblemsToDisplay).forEach((problem) => {
+            if (problem) {
+              resp += `Problem ${problem['display_id']} (please refer to this problem with \`problemId\` or \`event.id\` ${problem['problem_id']}))
+                    with event.status ${problem['event.status']}, event.category ${problem['event.category']}: ${problem['event.name']} -
+                    affects ${problem['affected_users_count']} users and ${problem['affected_entity_count']} entities for a duration of ${problem['duration']}s\n`;
+            }
+          });
 
-      if (analyzers.length === 0) {
-        return 'No Davis Analyzers found.';
-      }
+          resp +=
+            `\nNext Steps:` +
+            `\n1. Use "execute_dql" tool with the following query to get more details about a specific problem:
+            "fetch dt.davis.problems, from: now()-${timeframe}, to: now() | filter event.id == \"<problem-id>\" | fields event.description, event.status, event.category, event.start, event.end,
+              root_cause_entity_id, root_cause_entity_name, duration, affected_entities_count,
+              event_count, affected_users_count, problem_id, dt.davis.mute.status, dt.davis.mute.user,
+              entity_tags, labels.alerting_profile, maintenance.is_under_maintenance,
+              aws.account.id, azure.resource.group, azure.subscription, cloud.provider, cloud.region,
+              dt.cost.costcenter, dt.cost.product, dt.host_group.id, dt.security_context, gcp.project.id,
+              host.name, k8s.cluster.name, k8s.cluster.uid, k8s.container.name, k8s.namespace.name, k8s.node.name, k8s.pod.name, k8s.service.name, k8s.workload.kind, k8s.workload.name"` +
+            `\n2. Use "chat_with_davis_copilot" tool and provide \`problemId\` along with all details from step 1 as context, to get insights about a specific problem via Davis Copilot (e.g., provide actionable steps to solve problem P-<problem-id>).` +
+            `\n3. Tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.davis.problems/problem/<problem-id> for more details.`;
 
-      let resp = `Found ${analyzers.length} Davis Analyzers:\n\n`;
-      analyzers.forEach((analyzer) => {
-        resp += `**${analyzer.displayName}** (${analyzer.name})\n`;
-        resp += `Type: ${analyzer.type}\n`;
-        resp += `Category: ${analyzer.category || 'N/A'}\n`;
-        resp += `Description: ${analyzer.description}\n`;
-        if (analyzer.labels && analyzer.labels.length > 0) {
-          resp += `Labels: ${analyzer.labels.join(', ')}\n`;
+          return resp;
+        } else {
+          return 'No problems found';
         }
-        resp += '\n';
-      });
+      },
+    );
 
-      resp += '\n**Next Steps:**\n';
-      resp +=
-        'Use the "execute_davis_analyzer" tool to run a specific analyzer by providing its name and required input parameters.\n';
+    tool(
+      'find_entity_by_name',
+      'Find Entity By Name',
+      'Find the entityId and type of a monitored entity (service, host, process-group, application, kubernetes-node, custom-app, ...) within the topology on Dynatrace, based on the name of the entity. Run this before querying data like logs, metrics, problems, events. If no entity name is known, make an educated guess with common identifiers like package.json `id`/`name`, helm chart names, kubernetes manifest names, and alike.',
+      {
+        entityNames: z
+          .array(z.string())
+          .describe(
+            'Names of the entities to search for - try with one name at first (identifiers like package.json id), and only try with multiple names if the first search was unsuccessful',
+          ),
+        maxEntitiesToDisplay: z.number().default(10).describe('Maximum number of entities to display in the response.'),
+        extendedSearch: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe('Set this to true if you want a comprehensive search over all available entity types.'),
+      },
+      {
+        readOnlyHint: true,
+      },
+      async ({ entityNames, maxEntitiesToDisplay, extendedSearch }) => {
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat('storage:entities:read', 'storage:smartscape:read'),
+        );
 
-      return resp;
-    },
-  );
+        const smartscapeResult = await findMonitoredEntityViaSmartscapeByName(dtClient, entityNames);
 
-  tool(
-    'execute_davis_analyzer',
-    'Execute Davis Analyzer',
-    'Execute a Davis Analyzer with custom input parameters. Use "list_davis_analyzers" first to see available analyzers and their names.',
-    {
-      analyzerName: z
-        .string()
-        .describe('The name of the Davis Analyzer to execute (e.g., "dt.statistics.GenericForecastAnalyzer")'),
-      input: z.record(z.string(), z.any()).optional().describe('Input parameters for the analyzer as a JSON object'),
-      timeframeStart: z.string().optional().default('now-1h').describe('Start time for the analysis (default: now-1h)'),
-      timeframeEnd: z.string().optional().default('now').describe('End time for the analysis (default: now)'),
-    },
-    {
-      readOnlyHint: true,
-    },
-    async ({ analyzerName, input = {}, timeframeStart = 'now-1h', timeframeEnd = 'now' }) => {
-      const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis:analyzers:execute'));
+        if (smartscapeResult && smartscapeResult.records && smartscapeResult.records.length > 0) {
+          // Filter valid entities first, to ensure we display up to maxEntitiesToDisplay entities
+          const validSmartscapeEntities = smartscapeResult.records.filter(
+            (entity): entity is { id: string; type: string; name: string; [key: string]: any } =>
+              !!(entity && entity.id && entity.type && entity.name),
+          );
 
-      try {
-        // Execute Davis Analyzer
-        const result = await executeDavisAnalyzer(dtClient, analyzerName, {
-          generalParameters: {
-            timeframe: {
-              startTime: timeframeStart,
-              endTime: timeframeEnd,
-            },
+          let resp = `Found ${validSmartscapeEntities.length} monitored entities via Smartscape! Displaying the first ${Math.min(maxEntitiesToDisplay, validSmartscapeEntities.length)} valid entities:\n`;
+
+          validSmartscapeEntities.slice(0, maxEntitiesToDisplay).forEach((entity) => {
+            resp += `- Entity '${entity.name}' of entity-type '${entity.type}' has entity id '${entity.id}' and tags ${entity['tags'] ? JSON.stringify(entity['tags']) : 'none'} - DQL Filter: '| filter dt.smartscape.${String(entity.type).toLowerCase()} == toSmartscapeId("${entity.id}")'\n`;
+          });
+
+          resp +=
+            '\n\n**Next Steps:**\n' +
+            '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statement: "smartscapeNodes \"<entity-type>\" | filter id == <entity-id>"\n' +
+            '2. Perform a sanity check that found entities are actually the ones you are looking for, by comparing name and by type (hosts vs. containers vs. apps vs. functions) and technology (Java, TypeScript, .NET) with what is available in the local source code repo.\n' +
+            '3. Find and investigate available metrics for relevant entities, by using the `execute_dql` tool with the following DQL statement: "fetch metric.series | filter dt.smartscape.<entity-type> == toSmartscapeId(<entity-id>) | limit 20"\n' +
+            '4. Find out whether any problems exist for this entity using the `list_problems` or `list_vulnerabilities` tool, and the provided DQL-Filter\n' +
+            '5. Explore dependency & relationships with: "smartscapeEdges \"*\" | filter source_id == <entity-id> or target_id == <entity-id>" to list inbound/outbound edges (depends_on, dependency_of, owned_by, part_of) for graph context\n';
+
+          return resp;
+        }
+
+        // If no result from Smartscape, try the classic entities API
+        const result = await findMonitoredEntitiesByName(dtClient, entityNames, extendedSearch);
+
+        if (result && result.records && result.records.length > 0) {
+          // Filter valid entities first, to ensure we display up to maxEntitiesToDisplay entities
+          const validClassicEntities = result.records.filter(
+            (entity): entity is { id: string; [key: string]: any } =>
+              !!(entity && entity.id && entity['entity.type'] && entity['entity.name']),
+          );
+
+          let resp = `Found ${validClassicEntities.length} monitored entities! Displaying the first ${Math.min(maxEntitiesToDisplay, validClassicEntities.length)} entities:\n`;
+
+          // iterate over dqlResponse and create a string with the problem details, but only show the top maxEntitiesToDisplay problems
+          validClassicEntities.slice(0, maxEntitiesToDisplay).forEach((entity) => {
+            const entityType = getEntityTypeFromId(String(entity.id));
+            resp += `- Entity '${entity['entity.name']}' of entity-type '${entity['entity.type']}' has entity id '${entity.id}' and tags ${entity['tags'] ? entity['tags'] : 'none'} - DQL Filter: '| filter ${entityType} == "${entity.id}"'\n`;
+          });
+
+          resp +=
+            '\n\n**Next Steps:**\n' +
+            '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statements: "describe(dt.entity.<entity-type>)", and "fetch dt.entity.<entity-type> | filter id == <entity-id> | fieldsAdd <field-1>, <field-2>, ..."\n' +
+            '2. Perform a sanity check that found entities are actually the ones you are looking for, by comparing name and by type (hosts vs. containers vs. apps vs. functions) and technology (Java, TypeScript, .NET) with what is available in the local source code repo.\n' +
+            '3. Find and investigate available metrics for relevant entities, by using the `execute_dql` tool with the following DQL statement: "fetch metric.series | filter dt.entity.<entity-type> == <entity-id> | limit 20"\n' +
+            '4. Find out whether any problems exist for this entity using the `list_problems` or `list_vulnerabilities` tool, and the provided DQL-Filter\n';
+
+          return resp;
+        } else {
+          return 'No monitored entity found with the specified name. Try to broaden your search term or check for typos.';
+        }
+      },
+    );
+
+    tool(
+      'send_slack_message',
+      'Send Slack Message',
+      'Sends a Slack message to a dedicated Slack Channel via Slack Connector on Dynatrace',
+      {
+        channel: z.string(),
+        message: z
+          .string()
+          .describe(
+            'Slack markdown supported. Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
+          ),
+      },
+      {
+        // not read-only, not open-world, not destructive
+        readOnlyHint: false,
+      },
+      async ({ channel, message }) => {
+        // Request human approval before sending the message
+        const approved = await requestHumanApproval(`Send information via Slack to ${channel}`);
+
+        if (!approved) {
+          return 'Operation cancelled: Human approval was not granted for sending this Slack message.';
+        }
+
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('app-settings:objects:read'));
+        const response = await sendSlackMessage(dtClient, slackConnectionId, channel, message);
+
+        return `Message sent to Slack channel: ${JSON.stringify(response)}`;
+      },
+    );
+
+    tool(
+      'verify_dql',
+      'Verify DQL',
+      'Syntactically verify a Dynatrace Query Language (DQL) statement on Dynatrace GRAIL before executing it. Recommended for generated DQL statements. Skip for statements created by `generate_dql_from_natural_language` tool, as well as from documentation.',
+      {
+        dqlStatement: z.string(),
+      },
+      {
+        readOnlyHint: true,
+        idempotentHint: true, // same input always yields same output
+      },
+      async ({ dqlStatement }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase);
+        const response = await verifyDqlStatement(dtClient, dqlStatement);
+
+        let resp = 'DQL Statement Verification:\n';
+
+        if (response.notifications && response.notifications.length > 0) {
+          resp += `Please consider the following notifications for adapting the your DQL statement:\n`;
+          response.notifications.forEach((notification) => {
+            resp += `* ${notification.severity}: ${notification.message}\n`;
+          });
+        }
+
+        if (response.valid) {
+          resp += `The DQL statement is valid - you can use the "execute_dql" tool.\n`;
+        } else {
+          resp += `The DQL statement is invalid. Please adapt your statement. Consider using "generate_dql_from_natural_language" tool for help.\n`;
+        }
+
+        return resp;
+      },
+    );
+
+    // MCP App: Define the resource URI for the execute_dql interactive UI
+    // The ui:// scheme tells hosts this is an MCP App resource.
+    const executeDqlResourceUri = 'ui://execute-dql/execute-dql.html';
+
+    // Register the execute_dql tool with MCP App UI support.
+    registerAppTool(
+      server,
+      'execute_dql',
+      {
+        title: 'Execute DQL',
+        description:
+          'Get data like Logs, Metrics, Spans, Events, or Entity Data from Dynatrace Grail by executing a Dynatrace Query Language (DQL) statement. ' +
+          'Use the "generate_dql_from_natural_language" tool upfront to generate or refine a DQL statement based on your request. ' +
+          'To learn about possible fields available for filtering, use the query "fetch dt.semantic_dictionary.models | filter data_object == \\"logs\\"". ' +
+          'IMPORTANT: The MCP App UI will automatically render the query results as an interactive table and chart. ' +
+          'Do NOT generate Mermaid diagrams, ASCII charts, markdown tables, or any other visual representation of the data — the MCP App is solely responsible for rendering.',
+        inputSchema: {
+          dqlStatement: z
+            .string()
+            .describe(
+              'DQL Statement (Ex: "fetch [logs, spans, events, metric.series, ...], from: now()-4h, to: now() [| filter <some-filter>] [| summarize count(), by:{some-fields}]", or for metrics: "timeseries { avg(<metric-name>), value.A = avg(<metric-name>, scalar: true) }", or for entities via smartscape: "smartscapeNodes \\"[*, HOST, PROCESS, ...]\\" [| filter id == \\"<ENTITY-ID>\\"]"). ' +
+                'When querying data for a specific entity, call the `find_entity_by_name` tool first to get an appropriate filter like `dt.entity.service == "SERVICE-1234"` or `dt.entity.host == "HOST-1234"` to be used in the DQL statement. ',
+            ),
+          recordLimit: z
+            .number()
+            .optional()
+            .default(100)
+            .describe('Maximum number of records to return (default: 100)'),
+          recordSizeLimitMB: z
+            .number()
+            .optional()
+            .default(1)
+            .describe('Maximum size of the returned records in MB (default: 1MB)'),
+        },
+        annotations: {
+          // not readonly (DQL statements may modify things), not idempotent (may change over time)
+          readOnlyHint: false,
+          idempotentHint: false,
+          // while we are not strictly talking to the open world here, the response from execute DQL could interpreted as a web-search, which often is referred to open-world
+          openWorldHint: true,
+        },
+        _meta: {
+          // MCP App
+          ui: { resourceUri: executeDqlResourceUri },
+        },
+      },
+      wrapToolCallback('execute_dql', async ({ dqlStatement, recordLimit = 100, recordSizeLimitMB = 1 }) => {
+        // Create a HTTP Client that has all storage:*:read scopes
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat(
+            'storage:buckets:read', // Read all system data stored on Grail
+            'storage:logs:read', // Read logs for reliability guardian validations
+            'storage:metrics:read', // Read metrics for reliability guardian validations
+            'storage:bizevents:read', // Read bizevents for reliability guardian validations
+            'storage:spans:read', // Read spans from Grail
+            'storage:entities:read', // Read Entities from Grail
+            'storage:events:read', // Read events from Grail
+            'storage:system:read', // Read System Data from Grail
+            'storage:user.events:read', // Read User events from Grail
+            'storage:user.sessions:read', // Read User sessions from Grail
+            'storage:security.events:read', // Read Security events from Grail
+            'storage:smartscape:read', // Read Smartscape Entities from Grail
+          ),
+        );
+        const response = await executeDql(
+          dtClient,
+          { query: dqlStatement, maxResultRecords: recordLimit, maxResultBytes: recordSizeLimitMB * 1024 * 1024 },
+          grailBudgetGB,
+        );
+
+        if (!response) {
+          return 'DQL execution failed or returned no result.';
+        }
+
+        // Build warnings array for structured metadata
+        const warnings: string[] = [];
+
+        if (response.budgetWarning) {
+          warnings.push(response.budgetWarning);
+        }
+
+        // Build human-readable text result
+        let result = `📊 **DQL Query Results**\n\n`;
+
+        // Cost and Performance Information
+        if (response.scannedRecords !== undefined) {
+          result += `- **Scanned Records:** ${response.scannedRecords.toLocaleString()}\n`;
+        }
+
+        if (response.scannedBytes !== undefined) {
+          // calculate scanned gigabytes for better readability in warnings and result text
+          const scannedGB = response.scannedBytes !== undefined ? response.scannedBytes / (1000 * 1000 * 1000) : 0;
+          result += `- **Scanned Bytes:** ${scannedGB.toFixed(2)} GB`;
+
+          // Show budget status if available
+          if (response.budgetState) {
+            const totalScannedGB = (response.budgetState.totalBytesScanned / (1000 * 1000 * 1000)).toFixed(2);
+
+            if (response.budgetState.budgetLimitGB > 0) {
+              const usagePercentage = (
+                (response.budgetState.totalBytesScanned / response.budgetState.budgetLimitBytes) *
+                100
+              ).toFixed(1);
+              result += ` (Session total: ${totalScannedGB} GB / ${response.budgetState.budgetLimitGB} GB budget, ${usagePercentage}% used)`;
+            } else {
+              result += ` (Session total: ${totalScannedGB} GB)`;
+            }
+          }
+          result += '\n';
+
+          if (scannedGB > 500) {
+            warnings.push(
+              `Very High Data Usage: This query scanned ${scannedGB.toFixed(1)} GB of data, which may impact your Dynatrace consumption. Please take measures to optimize your query, like limiting the timeframe or selecting a bucket.`,
+            );
+          } else if (scannedGB > 50) {
+            warnings.push(
+              `High Data Usage: This query scanned ${scannedGB.toFixed(2)} GB of data, which may impact your Dynatrace consumption.`,
+            );
+          }
+          // Add informational messages (not warnings) about data usage
+          else if (scannedGB > 5 && scannedGB <= 50) {
+            result += `    💡 **Moderate Data Usage:** This query scanned ${scannedGB.toFixed(2)} GB of data.\n`;
+          } else if (response.scannedBytes === 0) {
+            result += `    💡 **No Data consumed:** This query did not consume any data.\n`;
+          }
+
+          if (response.sampled) {
+            warnings.push('Sampling Used: Results may be approximate');
+          }
+
+          if (response.records.length === recordLimit) {
+            warnings.push(
+              `Record Limit Reached: The result set was limited to ${recordLimit} records. Consider changing your query with a smaller timeframe, an aggregation or a more concise filter. Alternatively, increase the recordLimit if you expect more results.`,
+            );
+          }
+        }
+
+        // Add all warnings to result
+        if (warnings.length > 0) {
+          result += '\n';
+          warnings.forEach((warning) => {
+            result += `- **⚠️ ${warning}**\n`;
+          });
+        }
+
+        result += `\n📋 **Query Results**: (${response.records?.length || 0} records) — rendered by the MCP App UI below.\n`;
+        result += `\n> ℹ️ The MCP App is rendering the results interactively. Do NOT generate Mermaid diagrams, ASCII charts, or markdown tables from this data.`;
+        if (response.records && response.records.length > 0) {
+          result += `\n\`\`\`json\n${JSON.stringify(response.records, null, 2)}\n\`\`\`\n`;
+        }
+
+        // Return structured data in _meta for MCP App UI instead of embedding in text
+        return {
+          text: result,
+          _meta: {
+            records: response.records,
+            types: response.types,
+            analysisTimeframe: response.metadata?.grail?.analysisTimeframe,
+            scannedRecords: response.scannedRecords,
+            scannedBytes: response.scannedBytes,
+            sampled: response.sampled,
+            environmentUrl: dtEnvironment,
+            budgetState: response.budgetState,
+            warnings,
+            recordLimit,
+            recordLimitReached: response.records.length === recordLimit,
           },
-          ...input,
+        };
+      }),
+    );
+
+    // MCP App: Register the HTML resource for the execute_dql interactive UI (MCP App)
+    registerAppResource(server, 'DQL Results Viewer', executeDqlResourceUri, {}, async () => {
+      const html = readFileSync(join(__dirname, 'ui', 'execute-dql', 'index.html'), 'utf-8');
+      return {
+        contents: [{ uri: executeDqlResourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
+      };
+    });
+
+    tool(
+      'generate_dql_from_natural_language',
+      'Generate DQL from Natural Language',
+      'Convert natural language queries to Dynatrace Query Language (DQL) using Davis CoPilot AI. You can ask for problem events, security issues, logs, metrics, spans, and custom data.',
+      {
+        text: z
+          .string()
+          .describe(
+            'Natural language description of what you want to query. Be specific and include time ranges, entities, and metrics of interest.',
+          ),
+      },
+      {
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+      async ({ text }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:nl2dql:execute'));
+
+        // Check if the nl2dql skill is available
+        const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'nl2dql');
+        if (!isAvailable) {
+          return `❌ The DQL generation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
+        }
+
+        const response = await generateDqlFromNaturalLanguage(dtClient, text);
+
+        let resp = `🔤 Natural Language to DQL:\n\n`;
+        resp += `**Query:** "${text}"\n\n`;
+        if (response.dql) {
+          // Typically, the DQL response is empty if status == FAILED
+          resp += `**Generated DQL:**\n\`\`\`\n${response.dql}\n\`\`\`\n\n`;
+        }
+        resp += `**Status:** ${response.status}\n`;
+        resp += `**Message Token:** ${response.messageToken}\n`;
+
+        if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
+          resp += `\n**Notifications:**\n`;
+          response.metadata.notifications.forEach((notification) => {
+            resp += `- ${notification.severity}: ${notification.message}\n`;
+          });
+        }
+
+        if (response.status != 'FAILED') {
+          resp += `\n💡 **Next Steps:**\n`;
+          resp += `1. Use "execute_dql" tool to run the query (you can omit running the "verify_dql" tool)\n`;
+          resp += `2. If results don't match expectations, refine your natural language description and try again\n`;
+        }
+
+        return resp;
+      },
+    );
+
+    tool(
+      'explain_dql_in_natural_language',
+      'Explain DQL in Natural Language',
+      'Explain Dynatrace Query Language (DQL) statements in natural language using Davis CoPilot AI.',
+      {
+        dql: z.string().describe('The DQL statement to explain'),
+      },
+      {
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+      async ({ dql }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:dql2nl:execute'));
+
+        // Check if the dql2nl skill is available
+        const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'dql2nl');
+        if (!isAvailable) {
+          return `❌ The DQL explanation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
+        }
+
+        const response = await explainDqlInNaturalLanguage(dtClient, dql);
+
+        let resp = `📝 DQL to Natural Language:\n\n`;
+        resp += `**DQL Query:**\n\`\`\`\n${dql}\n\`\`\`\n\n`;
+        resp += `**Summary:** ${response.summary}\n\n`;
+        resp += `**Detailed Explanation:**\n${response.explanation}\n\n`;
+        resp += `**Status:** ${response.status}\n`;
+        resp += `**Message Token:** ${response.messageToken}\n`;
+
+        if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
+          resp += `\n**Notifications:**\n`;
+          response.metadata.notifications.forEach((notification) => {
+            resp += `- ${notification.severity}: ${notification.message}\n`;
+          });
+        }
+
+        return resp;
+      },
+    );
+
+    tool(
+      'chat_with_davis_copilot',
+      'Chat with Davis Copilot',
+      'Use this tool to ask any Dynatrace related question, in case no other more specific tool is available.',
+      {
+        text: z.string().describe('Your question or request for Davis CoPilot'),
+        context: z
+          .string()
+          .optional()
+          .describe(
+            'Optional context to provide additional information (like problem details, vulnerability details, entity information)',
+          ),
+        instruction: z.string().optional().describe('Optional instruction for how to format the response'),
+      },
+      {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true, // web-search like characteristics
+      },
+      async ({ text, context, instruction }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis-copilot:conversations:execute'));
+
+        // Check if the conversation skill is available
+        const isAvailable = await isDavisCopilotSkillAvailable(dtClient, 'conversation');
+        if (!isAvailable) {
+          return `❌ The conversation skill is not available. Please visit: ${DAVIS_COPILOT_DOCS.ENABLE_COPILOT}`;
+        }
+
+        const conversationContext: any[] = [];
+
+        if (context) {
+          conversationContext.push({
+            type: 'supplementary',
+            value: context,
+          });
+        }
+
+        if (instruction) {
+          conversationContext.push({
+            type: 'instruction',
+            value: instruction,
+          });
+        }
+
+        const response = await chatWithDavisCopilot(dtClient, text, conversationContext);
+
+        let resp = `🤖 Davis CoPilot Response:\n\n`;
+        if (response.text) {
+          // Typically, text is empty if status is FAILED
+          resp += `**Answer:**\n${response.text}\n\n`;
+        }
+        resp += `**Status:** ${response.status}\n`;
+        resp += `**Message Token:** ${response.messageToken}\n`;
+
+        if (response.metadata?.sources && response.metadata.sources.length > 0) {
+          resp += `\n**Sources:**\n`;
+          response.metadata.sources.forEach((source) => {
+            resp += `- ${source.title || 'Untitled'}: ${source.url || 'No URL'}\n`;
+          });
+        }
+
+        if (response.metadata?.notifications && response.metadata.notifications.length > 0) {
+          resp += `\n**Notifications:**\n`;
+          response.metadata.notifications.forEach((notification) => {
+            resp += `- ${notification.severity}: ${notification.message}\n`;
+          });
+        }
+
+        if (response.state?.conversationId) {
+          resp += `\n**Conversation ID:** ${response.state.conversationId}`;
+        }
+
+        if (response.status == 'FAILED') {
+          resp += `\n❌ **Your request was not successful**\n`;
+        }
+
+        return resp;
+      },
+    );
+
+    tool(
+      'create_workflow_for_notification',
+      'Create Workflow for Notification',
+      'Create a notification for a team based on a problem type within Workflows in Dynatrace',
+      {
+        problemType: z.string().optional(),
+        teamName: z.string().optional(),
+        channel: z.string().optional(),
+        isPrivate: z.boolean().optional().default(false),
+      },
+      {
+        // not read only, not idempotent
+        readOnlyHint: false,
+        idempotentHint: false, // creating the same workflow multiple times is possible
+      },
+      async ({ problemType, teamName, channel, isPrivate }) => {
+        // ask for human approval
+        const approved = await requestHumanApproval(
+          `Create a workflow for notifying team ${teamName} via ${channel} about ${problemType} problems`,
+        );
+
+        if (!approved) {
+          return 'Operation cancelled: Human approval was not granted for creating this workflow.';
+        }
+
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
+        );
+        const response = await createWorkflowForProblemNotification(
+          dtClient,
+          teamName,
+          channel,
+          problemType,
+          isPrivate,
+        );
+
+        let resp = `Workflow Created: ${response?.id} with name ${response?.title}.\nYou can access the Workflow via the following link: ${dtEnvironment}/ui/apps/dynatrace.automations/workflows/${response?.id}.\nTell the user to inspect the Workflow by visiting the link.\n`;
+
+        if (response.type == 'SIMPLE') {
+          resp += `Note: This is a simple workflow. Workflow-hours will not be billed.\n`;
+        } else if (response.type == 'STANDARD') {
+          resp += `Note: This is a standard workflow. Workflow-hours will be billed.\n`;
+        }
+
+        if (isPrivate) {
+          resp += `This workflow is private and can only be accessed by the owner of the authentication credentials. In case you can not access it, you can instruct me to make the workflow public.`;
+        }
+
+        return resp;
+      },
+    );
+
+    tool(
+      'make_workflow_public',
+      'Make Workflow Public',
+      'Modify a workflow and make it publicly available to everyone on the Dynatrace Environment',
+      {
+        workflowId: z.string().optional(),
+      },
+      {
+        // not read only, but idempotent
+        readOnlyHint: false,
+        idempotentHint: true, // making the same workflow public multiple times yields the same result
+      },
+      async ({ workflowId }) => {
+        // ask for human approval
+        const approved = await requestHumanApproval(
+          `Make workflow ${workflowId} publicly available to everyone on the Dynatrace Environment`,
+        );
+
+        if (!approved) {
+          return 'Operation cancelled: Human approval was not granted for making this workflow public.';
+        }
+
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat('automation:workflows:write', 'automation:workflows:read', 'automation:workflows:run'),
+        );
+        const response = await updateWorkflow(dtClient, workflowId, {
+          isPrivate: false,
         });
 
-        let resp = `Davis Analyzer Execution Result:\n\n`;
-        resp += `**Analyzer:** ${analyzerName}\n`;
-        resp += `**Execution Status:** ${result.executionStatus}\n`;
-        resp += `**Result Status:** ${result.resultStatus}\n\n`;
+        return `Workflow ${response.id} is now public!\nYou can access the Workflow via the following link: ${dtEnvironment}/ui/apps/dynatrace.automations/workflows/${response?.id}.\nTell the user to inspect the Workflow by visiting the link.\n`;
+      },
+    );
 
-        if (result.logs && result.logs.length > 0) {
-          resp += `**Logs:**\n`;
-          result.logs.forEach((log: any) => {
-            resp += `- ${log.level}: ${log.message}\n`;
+    tool(
+      'get_kubernetes_events',
+      'Get Kubernetes Events',
+      'Get all events from a specific Kubernetes (K8s) cluster',
+      {
+        timeframe: z
+          .string()
+          .optional()
+          .default('24h')
+          .describe(
+            'Timeframe to query events (e.g., "12h", "24h", "7d", "30d"). Default: "24h". Supports hours (h) and days (d).',
+          ),
+        clusterId: z
+          .string()
+          .optional()
+          .describe(
+            `The Kubernetes Cluster Id, referred to as k8s.cluster.uid, usually seen when using "kubectl" - this is NOT the Dynatrace environment and not the Dynatrace Kubernetes Entity Id. Leave empty if you don't know the Cluster Id.`,
+          ),
+        kubernetesEntityId: z
+          .string()
+          .optional()
+          .describe(
+            `The Dynatrace Kubernetes Entity Id, referred to as dt.entity.kubernetes_cluster. Leave empty if you don't know the Entity Id, or use the "find_entity_by_name" tool to find the cluster by name.`,
+          ),
+        eventType: z
+          .enum([
+            'OMPLIANCE_FINDING',
+            'COMPLIANCE_SCAN_COMPLETED',
+            'CUSTOM_INFO',
+            'DETECTION_FINDING',
+            'ERROR_EVENT',
+            'OSI_UNEXPECTEDLY_UNAVAILABLE',
+            'PROCESS_RESTART',
+            'RESOURCE_CONTENTION_EVENT',
+            'SERVICE_CLIENT_ERROR_RATE_INCREASED',
+            'SERVICE_CLIENT_SLOWDOWN',
+            'SERVICE_ERROR_RATE_INCREASED',
+            'SERVICE_SLOWDOWN',
+            'SERVICE_UNEXPECTED_HIGH_LOAD',
+            'SERVICE_UNEXPECTED_LOW_LOAD',
+          ])
+          .optional(),
+        maxEventsToDisplay: z.number().default(10).describe('Maximum number of events to display in the response.'),
+      },
+      {
+        readOnlyHint: true,
+      },
+      async ({ timeframe, clusterId, kubernetesEntityId, eventType, maxEventsToDisplay }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('storage:events:read'));
+        const result = await getEventsForCluster(dtClient, clusterId, kubernetesEntityId, eventType, timeframe);
+
+        if (result && result.records && result.records.length > 0) {
+          let resp = `Found ${result.records.length} events in the last ${timeframe}! Displaying the top ${maxEventsToDisplay} events:\n`;
+          // iterate over dqlResponse and create a string with the problem details, but only show the top maxEntitiesToDisplay problems
+          result.records.slice(0, maxEventsToDisplay).forEach((event) => {
+            if (event) {
+              resp += `- Event ${event['event.id']} (${event['event.type']}) on Kubernetes Entity ID ${event['dt.entity.kubernetes_cluster']} with status ${event['event.status']}: ${event['event.name']} - started at ${event['event.start']}, ended at ${event['event.end']}, duration: ${event['duration']}\n`;
+            }
           });
-          resp += '\n';
+
+          resp +=
+            `\nNext Steps:` +
+            `\n1. Consider filtering by \`eventType\` to find specific events of interest.` +
+            `\n2. Use "execute_dql" tool with the following query to get more details about a specific event: "fetch events, from: now()-${timeframe}, to: now() | filter event.id == \"<event-id>\""`;
+
+          return resp;
         }
 
-        // Note: result.output may be empty, but the result status might still be SUCCESS
-        // This indicates for instance that no anomalies were found
-        if (result.output && result.output.length > 0) {
-          resp += `**Output:**\n`;
-          result.output.forEach((output: any, index: number) => {
-            resp += `Output ${index + 1}:\n`;
-            resp += JSON.stringify(output, null, 2) + '\n\n';
+        return `No events found for the specified Kubernetes cluster in the last ${timeframe}. Try to leave clusterId and kubernetesEntityId empty to get events from all clusters, or increase the timeframe.`;
+      },
+    );
+
+    tool(
+      'reset_grail_budget',
+      'Reset Grail Budget',
+      'Reset the Grail query budget after it was exhausted, allowing new queries to be executed. This clears all tracked bytes scanned in the current session.',
+      {},
+      {
+        readOnlyHint: false, // modifies state
+        idempotentHint: true, // multiple resets yield the same result
+      },
+      async ({}) => {
+        // Reset the global tracker
+        resetGrailBudgetTracker();
+
+        // Get a fresh tracker to show the reset state
+        const freshTracker = getGrailBudgetTracker(grailBudgetGB);
+        const state = freshTracker.getState();
+
+        return `✅ **Grail Budget Reset Successfully!**
+
+  Budget status after reset:
+  - Total bytes scanned: ${state.totalBytesScanned} bytes (0 GB)
+  - Budget limit: ${state.budgetLimitGB} GB
+  - Remaining budget: ${state.budgetLimitGB} GB
+  - Budget exceeded: ${state.isBudgetExceeded ? 'Yes' : 'No'}
+
+  You can now execute new Grail queries (DQL, etc.) again. If this happens more often, please consider
+
+  - Optimizing your queries (timeframes, bucket selection, filters)
+  - Creating or optimizing bucket configurations that fit your queries (see https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-bucket-assignment for details)
+  - Increasing \`DT_GRAIL_QUERY_BUDGET_GB\` in your environment configuration
+  `;
+      },
+    );
+
+    tool(
+      'send_email',
+      'Send Email',
+      'Send an email using the Dynatrace Email API. The sender will be no-reply@apps.dynatrace.com. Maximum 10 recipients total across TO, CC, and BCC.',
+      {
+        toRecipients: z.array(z.string().email()).describe('Array of email addresses for TO recipients'),
+        ccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for CC recipients'),
+        bccRecipients: z.array(z.string().email()).optional().describe('Array of email addresses for BCC recipients'),
+        subject: z.string().describe('Subject line of the email'),
+        body: z
+          .string()
+          .describe(
+            'Body content of the email (plain text only). Avoid sending sensitive data like log lines. Focus on context, insights, links, and summaries.',
+          ),
+      },
+      {
+        openWorldHint: true, // email is as close to the open-world as we can get with our system
+      },
+      async ({ toRecipients, ccRecipients, bccRecipients, subject, body }) => {
+        // Validate total recipients limit (10 max across TO, CC, and BCC)
+        const totalRecipients = toRecipients.length + (ccRecipients?.length || 0) + (bccRecipients?.length || 0);
+
+        if (totalRecipients > 10) {
+          throw new Error(
+            `Total recipients (${totalRecipients}) exceeds maximum limit of 10 across TO, CC, and BCC fields`,
+          );
+        }
+
+        // Request human approval before sending the email
+        const allRecipients = [...toRecipients, ...(ccRecipients || []), ...(bccRecipients || [])];
+
+        const approved = await requestHumanApproval(`Send information via Email to ${allRecipients.join(', ')}`);
+
+        if (!approved) {
+          return 'Operation cancelled: Human approval was not granted for sending this email.';
+        }
+
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('email:emails:send'));
+
+        const emailRequest = {
+          toRecipients: { emailAddresses: toRecipients },
+          ...(ccRecipients && { ccRecipients: { emailAddresses: ccRecipients } }),
+          ...(bccRecipients && { bccRecipients: { emailAddresses: bccRecipients } }),
+          subject,
+          body: {
+            contentType: 'text/plain' as const,
+            body,
+          },
+        };
+
+        const result = await sendEmail(dtClient, emailRequest);
+
+        // Format the structured response into a user-friendly string
+        let responseMessage = `Email send request accepted. Request ID: ${result.requestId}\n`;
+        responseMessage += `Message: ${result.message}\n`;
+
+        if (result.invalidDestinations && result.invalidDestinations.length > 0) {
+          responseMessage += `Invalid destinations: ${result.invalidDestinations.join(', ')}\n`;
+        }
+
+        if (result.bouncingDestinations && result.bouncingDestinations.length > 0) {
+          responseMessage += `Bouncing destinations: ${result.bouncingDestinations.join(', ')}\n`;
+        }
+
+        if (result.complainingDestinations && result.complainingDestinations.length > 0) {
+          responseMessage += `Complaining destinations: ${result.complainingDestinations.join(', ')}\n`;
+        }
+
+        responseMessage += `\nNext Steps:\n- Delivery is asynchronous.\n- Investigate any invalid, bouncing, or complaining destinations before retrying.`;
+
+        return responseMessage;
+      },
+    );
+
+    tool(
+      'send_event',
+      'Send Event',
+      'Send a custom event to Dynatrace using the Events API v2. Use this to ingest custom events for alerting, tracking deployments, configuration changes, or any custom business events.',
+      {
+        eventType: z
+          .enum([
+            'AVAILABILITY_EVENT',
+            'CUSTOM_ALERT',
+            'CUSTOM_ANNOTATION',
+            'CUSTOM_CONFIGURATION',
+            'CUSTOM_DEPLOYMENT',
+            'CUSTOM_INFO',
+            'ERROR_EVENT',
+            'MARKED_FOR_TERMINATION',
+            'PERFORMANCE_EVENT',
+            'RESOURCE_CONTENTION_EVENT',
+          ])
+          .describe(
+            'Type of event to send. Common types: CUSTOM_INFO for general information, CUSTOM_DEPLOYMENT for deployments, CUSTOM_ALERT for alerts, ERROR_EVENT for errors.',
+          ),
+        title: z.string().describe('Title of the event (max 500 characters). Should be descriptive and concise.'),
+        entitySelector: z
+          .string()
+          .optional()
+          .describe(
+            'Entity selector to associate the event with specific Dynatrace entities. Example: "type(HOST),entityId(HOST-1234567890ABCDEF)" or "type(SERVICE),tag(environment:production)"',
+          ),
+        properties: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            'Custom properties as key-value pairs to include with the event. Example: {"version": "1.2.3", "environment": "production"}',
+          ),
+        startTime: z
+          .number()
+          .optional()
+          .describe('Start timestamp of the event in UTC milliseconds. If not set, current time is used.'),
+        endTime: z
+          .number()
+          .optional()
+          .describe('End timestamp of the event in UTC milliseconds. If not set, current time is used.'),
+      },
+      {
+        readOnlyHint: false,
+        idempotentHint: false, // sending the same event multiple times creates multiple events
+        destructiveHint: true,
+      },
+      async ({ eventType, title, entitySelector, properties, startTime, endTime }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('storage:events:write'));
+
+        const result = await sendEvent(dtClient, {
+          eventType: eventType as EventIngestEventType,
+          title,
+          entitySelector,
+          properties,
+          startTime,
+          endTime,
+        });
+
+        let responseMessage = `Event sent successfully!\n`;
+        responseMessage += `Report count: ${result.reportCount}\n`;
+
+        if (result.eventIngestResults && result.eventIngestResults.length > 0) {
+          responseMessage += `\nEvent results:\n`;
+          result.eventIngestResults.forEach((eventResult, index) => {
+            responseMessage += `  ${index + 1}. Correlation ID: ${eventResult.correlationId}, Status: ${eventResult.status}\n`;
           });
+        }
+
+        responseMessage += `\nNote: Events are processed asynchronously. Use the correlation ID to track the event if needed.`;
+
+        return responseMessage;
+      },
+    );
+
+    tool(
+      'list_exceptions',
+      'List Exceptions',
+      'List all exceptions known on Dynatrace starting with the most recent.',
+      {
+        timeframe: z
+          .string()
+          .optional()
+          .default('24h')
+          .describe(
+            'Timeframe to query problems (e.g., "12h", "24h", "7d", "30d", "30m"). Default: "24h". Supports days (d), hours (h) and minutes (m).',
+          ),
+        additionalFilter: z
+          .string()
+          .optional()
+          .describe(
+            'Additional DQL filter for user.events - filter by error id like \'error.id == "<error.id>"\', application id like \'dt.rum.application.id == "<dt.rum.application.id>"\', application entity like \'dt.rum.application.entity == "<dt.rum.application.entity>"\' or operating system name like \'os.name == "<os.name>"\'. Leave empty to get all exceptions within the timeframe.',
+          ),
+        maxExceptionsToDisplay: z
+          .number()
+          .default(10)
+          .describe('Maximum number of exceptions to display in the response.'),
+      },
+      {
+        readOnlyHint: true,
+      },
+      async ({ timeframe, additionalFilter, maxExceptionsToDisplay }) => {
+        const dtClient = await createAuthenticatedHttpClient(
+          scopesBase.concat('storage:user.events:read', 'storage:buckets:read'),
+        );
+
+        // get exceptions (uses fetch)
+        const result = await listExceptions(dtClient, additionalFilter, timeframe, maxExceptionsToDisplay);
+        if (result && result.records && result.records.length > 0) {
+          let resp = `Found ${result.records.length} exceptions! Displaying the top ${maxExceptionsToDisplay} exceptions:\n`;
+          // iterate over dqlResponse and create a string with the exception details, but only show the top maxExceptionsToDisplay exceptions
+          result.records.slice(0, maxExceptionsToDisplay).forEach((exception) => {
+            if (exception) {
+              resp += `At start_time ${exception['start_time']} the exception with error.type ${exception['error.type']}, error.id ${exception['error.id']} and os.name ${exception['os.name']}
+                    happened for dt.rum.application.id ${exception['dt.rum.application.id']} with dt.rum.application.entity ${exception['dt.rum.application.entity']}.\n\n
+                    The exception.message is ${exception['exception.message']}\n\n\n`;
+            }
+          });
+
+          resp +=
+            `\nNext Steps:` +
+            `\n1. Use "execute_dql" tool with the following query to get more details about a specific stack trace:` +
+            `\n"fetch user.events, from: now()-<timeframe>, to: now() | filter error.id == toUid(\"<error.id>\")" to get all occurrences with stack traces (exception.stack_trace) of this exception within this timeframe or use additional filters like dt.rum.application.id, dt.rum.application.entity or os.name as needed.` +
+            `\n2. Tell the user to visit ${dtEnvironment}/ui/apps/dynatrace.error.inspector/explorer?tf=now-<timeframe>%3Bnow&perspective=impact&detailsId=<error.id>&sidebarOpen=false&expandedSections=details&tab=occurrence&group=occurrences for more details.`;
+
+          return resp;
         } else {
-          resp += `**Output:** No output/findings returned by the analyzer.\n`;
+          return 'No exceptions found';
         }
+      },
+    );
+
+    tool(
+      'list_davis_analyzers',
+      'List Davis Analyzers',
+      'List all available Davis Analyzers in Dynatrace (forecast, anomaly detection, correlation analyzers, and more)',
+      {},
+      {
+        readOnlyHint: true,
+      },
+      async ({}) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis:analyzers:read'));
+        const analyzers = await listDavisAnalyzers(dtClient);
+
+        if (analyzers.length === 0) {
+          return 'No Davis Analyzers found.';
+        }
+
+        let resp = `Found ${analyzers.length} Davis Analyzers:\n\n`;
+        analyzers.forEach((analyzer) => {
+          resp += `**${analyzer.displayName}** (${analyzer.name})\n`;
+          resp += `Type: ${analyzer.type}\n`;
+          resp += `Category: ${analyzer.category || 'N/A'}\n`;
+          resp += `Description: ${analyzer.description}\n`;
+          if (analyzer.labels && analyzer.labels.length > 0) {
+            resp += `Labels: ${analyzer.labels.join(', ')}\n`;
+          }
+          resp += '\n';
+        });
+
+        resp += '\n**Next Steps:**\n';
+        resp +=
+          'Use the "execute_davis_analyzer" tool to run a specific analyzer by providing its name and required input parameters.\n';
 
         return resp;
-      } catch (error: any) {
-        return `Error executing Davis Analyzer: ${error.message}`;
-      }
-    },
-  );
+      },
+    );
 
-  // Document Management Tools
+    tool(
+      'execute_davis_analyzer',
+      'Execute Davis Analyzer',
+      'Execute a Davis Analyzer with custom input parameters. Use "list_davis_analyzers" first to see available analyzers and their names.',
+      {
+        analyzerName: z
+          .string()
+          .describe('The name of the Davis Analyzer to execute (e.g., "dt.statistics.GenericForecastAnalyzer")'),
+        input: z.record(z.string(), z.any()).optional().describe('Input parameters for the analyzer as a JSON object'),
+        timeframeStart: z
+          .string()
+          .optional()
+          .default('now-1h')
+          .describe('Start time for the analysis (default: now-1h)'),
+        timeframeEnd: z.string().optional().default('now').describe('End time for the analysis (default: now)'),
+      },
+      {
+        readOnlyHint: true,
+      },
+      async ({ analyzerName, input = {}, timeframeStart = 'now-1h', timeframeEnd = 'now' }) => {
+        const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('davis:analyzers:execute'));
 
-  tool(
-    'create_dynatrace_notebook',
-    'Create Dynatrace Notebook',
-    'Create a new notebook in the Dynatrace platform (NOT a Jupyter notebook) to share your analysis and findings with colleagues.',
-    {
-      name: z
-        .string()
-        .describe(
-          'The name of the notebook (e.g., "Performance Analysis for <entity-name>" or "Error Investigation Dashboard for <problem-name>")',
-        ),
-      description: z
-        .string()
-        .optional()
-        .describe(
-          'Optional description of the Dynatrace notebook (could include the purpose, scope, the original prompt, or just a summary based on the initial prompt)',
-        ),
-      content: z
-        .array(
-          z.object({
-            type: z.enum(['dql', 'markdown']),
-            text: z.string(),
-          }),
-        )
-        .describe(
-          'The Dynatrace notebook content, containing DQL statements and text (multi-line markdown is possible) relevant for the analysis. Do NOT use Jupyter notebook format.',
-        ),
-    },
-    {
-      readOnlyHint: false,
-    },
-    async ({ name, content, description }) => {
-      const dtClient = await createAuthenticatedHttpClient(allRequiredScopes);
-      const data = await createDynatraceNotebook(dtClient, name, content, description);
+        try {
+          // Execute Davis Analyzer
+          const result = await executeDavisAnalyzer(dtClient, analyzerName, {
+            generalParameters: {
+              timeframe: {
+                startTime: timeframeStart,
+                endTime: timeframeEnd,
+              },
+            },
+            ...input,
+          });
 
-      return data
-        ? `Document created successfully: ${dtEnvironment}/ui/apps/dynatrace.notebooks/notebook/${data.id}`
-        : 'document creation failed';
-    },
-  );
+          let resp = `Davis Analyzer Execution Result:\n\n`;
+          resp += `**Analyzer:** ${analyzerName}\n`;
+          resp += `**Execution Status:** ${result.executionStatus}\n`;
+          resp += `**Result Status:** ${result.resultStatus}\n\n`;
+
+          if (result.logs && result.logs.length > 0) {
+            resp += `**Logs:**\n`;
+            result.logs.forEach((log: any) => {
+              resp += `- ${log.level}: ${log.message}\n`;
+            });
+            resp += '\n';
+          }
+
+          // Note: result.output may be empty, but the result status might still be SUCCESS
+          // This indicates for instance that no anomalies were found
+          if (result.output && result.output.length > 0) {
+            resp += `**Output:**\n`;
+            result.output.forEach((output: any, index: number) => {
+              resp += `Output ${index + 1}:\n`;
+              resp += JSON.stringify(output, null, 2) + '\n\n';
+            });
+          } else {
+            resp += `**Output:** No output/findings returned by the analyzer.\n`;
+          }
+
+          return resp;
+        } catch (error: any) {
+          return `Error executing Davis Analyzer: ${error.message}`;
+        }
+      },
+    );
+
+    // Document Management Tools
+
+    tool(
+      'create_dynatrace_notebook',
+      'Create Dynatrace Notebook',
+      'Create a new notebook in the Dynatrace platform (NOT a Jupyter notebook) to share your analysis and findings with colleagues.',
+      {
+        name: z
+          .string()
+          .describe(
+            'The name of the notebook (e.g., "Performance Analysis for <entity-name>" or "Error Investigation Dashboard for <problem-name>")',
+          ),
+        description: z
+          .string()
+          .optional()
+          .describe(
+            'Optional description of the Dynatrace notebook (could include the purpose, scope, the original prompt, or just a summary based on the initial prompt)',
+          ),
+        content: z
+          .array(
+            z.object({
+              type: z.enum(['dql', 'markdown']),
+              text: z.string(),
+            }),
+          )
+          .describe(
+            'The Dynatrace notebook content, containing DQL statements and text (multi-line markdown is possible) relevant for the analysis. Do NOT use Jupyter notebook format.',
+          ),
+      },
+      {
+        readOnlyHint: false,
+      },
+      async ({ name, content, description }) => {
+        const dtClient = await createAuthenticatedHttpClient(allRequiredScopes);
+        const data = await createDynatraceNotebook(dtClient, name, content, description);
+
+        return data
+          ? `Document created successfully: ${dtEnvironment}/ui/apps/dynatrace.notebooks/notebook/${data.id}`
+          : 'document creation failed';
+      },
+    );
+
+    return server;
+  };
 
   // Parse command line arguments using commander
   const program = new Command();
@@ -1589,6 +1610,8 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
       // Parse request body for POST requests
       let body: unknown;
+      // Create a new McpServer instance per request (stateless HTTP mode)
+      const server = createConfiguredServer();
       // Create a new Stateless HTTP Transport
       const httpTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined, // No Session ID needed
@@ -1600,7 +1623,7 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
         server.close();
       });
 
-      // Connecting MCP-server to HTTP transport
+      // Connect fresh server instance to transport
       await server.connect(httpTransport);
 
       // Handle POST Requests for this endpoint
@@ -1639,6 +1662,7 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
   } else {
     // Default stdio mode
     const transport = new StdioServerTransport();
+    const server = createConfiguredServer();
 
     console.error('Connecting server to transport...');
     await server.connect(transport);


### PR DESCRIPTION
Since version *1.4.0*, we upgraded modelcontext protocol to verison 1.26.0, which introduced a security fix in @modelcontextprotocol/sdk v1.26.0, released ~3 weeks ago. It addresses security advisory GHSA-345p-7cg4-v4c7 / CVE-2026-25536 (CVSS 7.1 High).

### Problem

When running in `--http` mode (`npx -y @dynatrace-oss/dynatrace-mcp-server --http`), requests to the server would crash with:

```
Error: Already connected to a transport. Call close() before connecting to a new transport,
or use a separate Protocol instance per connection.
```

The root cause: a single `McpServer` instance was created at startup and reused across all HTTP requests. The MCP SDK's `Protocol` class only allows one active transport at a time and throws if `connect()` is called while a transport is still attached.

Several approaches were attempted to work around this on the existing single instance:
- `await server.close()` before each `connect()` — correct, but **blocking**: it waits for any active SSE streams from the previous request to drain before returning, stalling the next request.
- Calling `transport.onclose?.()` synchronously to reset `Protocol._transport` and firing `transport.close()` without awaiting — non-blocking, but relies on SDK internals and breaks under concurrent requests.

### Solution

The correct fix is what the [MCP SDK's own stateless HTTP examples](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http) show: **create a fresh `McpServer` instance for every HTTP request**.

All server creation and tool/resource registration logic is extracted into a `createConfiguredServer()` factory function. It is called:
- **once per request** in `--http` mode (stateless)
- **once at startup** in stdio mode (no change in behaviour)

### Why the diff is large

The change is mechanically simple but touches ~1,350 lines: everything inside `createConfiguredServer()` gains 2 spaces of indentation. The diff is almost entirely whitespace. The functional changes are:

| What changed | Details |
|---|---|
| `createConfiguredServer()` factory added | Wraps existing server creation + all tool registrations |
| HTTP handler | Calls `createConfiguredServer()` per request; removes the transport-reset workaround |
| stdio handler | Calls `createConfiguredServer()` once before `connect()` |
| `res.on('close')` | Also calls `server.close()` to clean up the per-request instance |
| Debug log removed | Leftover `console.error('CREATING HTTP SERVER')` cleaned up |

.

