### PR TITLE
patch: Updated DQL statements for smartscapeNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Refined instructions for DQL statements (related to `smartscapeNodes` and `smartscapeEdges`) to use `toSmartscapeId()`, ensuring correct type casting when querying Smartscape topology data.
+
 ## 1.5.2
 
 - Fixed a race condition in the OAuth Authorization Code Flow token refresh that caused browser windows to open unexpectedly during server operation. Concurrent token refresh attempts now share a single in-flight refresh request, preventing the refresh token from being consumed multiple times.

--- a/src/index.ts
+++ b/src/index.ts
@@ -566,11 +566,11 @@ const main = async () => {
 
         resp +=
           '\n\n**Next Steps:**\n' +
-          '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statement: "smartscapeNodes \"<entity-type>\" | filter id == <entity-id>"\n' +
+          '1. Fetch more details about the entity, using the `execute_dql` tool with the following DQL Statement: "smartscapeNodes \"<entity-type>\" | filter id == toSmartscapeId("<entity-id>)"\n' +
           '2. Perform a sanity check that found entities are actually the ones you are looking for, by comparing name and by type (hosts vs. containers vs. apps vs. functions) and technology (Java, TypeScript, .NET) with what is available in the local source code repo.\n' +
           '3. Find and investigate available metrics for relevant entities, by using the `execute_dql` tool with the following DQL statement: "fetch metric.series | filter dt.smartscape.<entity-type> == toSmartscapeId(<entity-id>) | limit 20"\n' +
           '4. Find out whether any problems exist for this entity using the `list_problems` or `list_vulnerabilities` tool, and the provided DQL-Filter\n' +
-          '5. Explore dependency & relationships with: "smartscapeEdges \"*\" | filter source_id == <entity-id> or target_id == <entity-id>" to list inbound/outbound edges (depends_on, dependency_of, owned_by, part_of) for graph context\n';
+          '5. Explore dependency & relationships with: "smartscapeEdges \"*\" | filter source_id == toSmartscapeId(<entity-id>) or target_id == toSmartscapeId(<entity-id>)" to list inbound/outbound edges (e.g., runs_on, belongs_to, calls, is_called_by) for graph context\n';
 
         return resp;
       }
@@ -693,7 +693,8 @@ const main = async () => {
           .string()
           .describe(
             'DQL Statement (Ex: "fetch [logs, spans, events, metric.series, ...], from: now()-4h, to: now() [| filter <some-filter>] [| summarize count(), by:{some-fields}]", or for metrics: "timeseries { avg(<metric-name>), value.A = avg(<metric-name>, scalar: true) }", or for entities via smartscape: "smartscapeNodes \\"[*, HOST, PROCESS, ...]\\" [| filter id == \\"<ENTITY-ID>\\"]"). ' +
-              'When querying data for a specific entity, call the `find_entity_by_name` tool first to get an appropriate filter like `dt.entity.service == "SERVICE-1234"` or `dt.entity.host == "HOST-1234"` to be used in the DQL statement. ',
+              'When querying data for a specific entity, call the `find_entity_by_name` tool first to get an appropriate filter like `dt.entity.service == "SERVICE-1234"` or `dt.entity.host == "HOST-1234"` to be used in the DQL statement. ' +
+              'Note: `dt.entity.*` filters only work in `fetch` queries (logs, metrics, spans, etc.). For `smartscapeNodes`, filter by `id == toSmartscapeId("<ENTITY-ID>")` or simply `id == "<ENTITY-ID>"` (raw string). For `smartscapeEdges`, use `source_id == toSmartscapeId("<ENTITY-ID>")` or `target_id == toSmartscapeId("<ENTITY-ID>")`. String functions like `contains()` or `startsWith()` do NOT work on smartscape `id` fields. ',
           ),
         recordLimit: z.number().optional().default(100).describe('Maximum number of records to return (default: 100)'),
         recordSizeLimitMB: z


### PR DESCRIPTION
There are some changes coming to DQL related to smartscape, and we need to ensure that LLMs pick up the  `toSmartscapeId` type-conversion.

https://docs.dynatrace.com/docs/platform/grail/dynatrace-query-language/functions/conversion-and-casting-functions#toSmartscapeId