### PR TITLE
feat(ui): improve execute-dql surface styling with Strato design tokens

### DIFF
--- a/src/ui/components/LoadingState.tsx
+++ b/src/ui/components/LoadingState.tsx
@@ -1,5 +1,4 @@
 import { Flex } from '@dynatrace/strato-components/layouts';
-import { Text } from '@dynatrace/strato-components/typography';
 import { ProgressCircle } from '@dynatrace/strato-components/content';
 
 interface LoadingStateProps {
@@ -9,8 +8,7 @@ interface LoadingStateProps {
 export function LoadingState({ message = 'Loading...' }: LoadingStateProps) {
   return (
     <Flex justifyContent='center' alignItems='center' padding={32}>
-      <ProgressCircle />
-      <Text>{message}</Text>
+      <ProgressCircle>{message}</ProgressCircle>
     </Flex>
   );
 }

--- a/src/ui/components/global.css
+++ b/src/ui/components/global.css
@@ -13,6 +13,13 @@ body,
   margin: 0 !important;
 }
 
+.execute-dql-results-surface {
+  background-color: var(--dt-colors-background-surface-default);
+  border: 1px solid var(--dt-colors-border-neutral-default);
+  border-radius: var(--dt-borders-radius-surface-default);
+  padding: 8px;
+}
+
 .execute-dql-toolbar {
   flex-wrap: wrap;
 }
@@ -26,19 +33,10 @@ body,
   flex-wrap: wrap;
 }
 
-.execute-dql-primary-actions {
-  margin-left: auto;
-}
-
 @media (max-width: 760px) {
   .execute-dql-toolbar-actions {
     margin-left: 0 !important;
     width: 100%;
-  }
-
-  .execute-dql-primary-actions {
-    margin-left: auto;
-    justify-content: flex-end;
   }
 }
 

--- a/src/ui/execute-dql/ExecuteDqlApp.tsx
+++ b/src/ui/execute-dql/ExecuteDqlApp.tsx
@@ -22,7 +22,7 @@ import { createNotebooksURL } from '../../utils/environment-url-parser';
 import { safeConvertToTimeseries } from './dql-chart-helpers';
 
 // Constants
-const RECORD_COUNT_TEXT_OPACITY = 0.5;
+const SUBDUED_TEXT_COLOR = 'var(--dt-colors-text-neutral-subdued)';
 const EMPTY_STATE_TEXT_OPACITY = 0.6;
 const DEFAULT_PAGE_SIZE = 10;
 
@@ -346,64 +346,66 @@ export function ExecuteDqlApp() {
   const { metadata } = state;
 
   return (
-    <Flex flexDirection='column' gap={4} className='execute-dql-app'>
-      {/* Compact metadata toolbar */}
-      <Flex
-        flexDirection='row'
-        gap={12}
-        alignItems='center'
-        padding={4}
-        style={{ paddingLeft: 8 }}
-        className='execute-dql-toolbar'
-      >
-        <Text textStyle='small' className='execute-dql-record-count'>
-          {state.records.length} {state.records.length === 1 ? 'record' : 'records'}
-        </Text>
-        {metadataText && (
-          <Text textStyle='small' style={{ opacity: RECORD_COUNT_TEXT_OPACITY }} className='execute-dql-metadata-text'>
-            {metadataText}
-          </Text>
-        )}
-        {metadata.warnings.length > 0 && (
-          <Flex flexDirection='row' gap={8} alignItems='center' className='execute-dql-warnings'>
-            {metadata.warnings.map((warning, i) => (
-              <MetadataIcon key={`${warning}-${i}`} icon={<WarningIcon />} tooltip={warning} warning />
-            ))}
-          </Flex>
-        )}
-        <Flex
-          flexDirection='row'
-          gap={4}
-          alignItems='center'
-          style={{ marginLeft: 'auto' }}
-          className='execute-dql-toolbar-actions'
-        >
-          <ToggleButtonGroup
-            value={toggleValue}
-            onChange={(val) => setToggleValue(val as CombinedChartVariantToggleValue)}
+    <div className='execute-dql-results-surface'>
+      <Flex flexDirection='column' gap={8} className='execute-dql-app'>
+        {/* Compact metadata toolbar */}
+        <Flex flexDirection='row' gap={12} alignItems='center' className='execute-dql-toolbar'>
+          <Text
+            textStyle='small'
+            style={{ color: 'var(--dt-colors-text-neutral-default)' }}
+            className='execute-dql-record-count'
           >
-            <Tooltip text='Table'>
-              <ToggleButtonGroup.Item value='table' aria-label='Switch to table view'>
-                <DataTableIcon />
-              </ToggleButtonGroup.Item>
-            </Tooltip>
-            <Tooltip text='Line'>
-              <ToggleButtonGroup.Item value='line' disabled={!canChart} aria-label='Switch to line chart view'>
-                <LineChartIcon />
-              </ToggleButtonGroup.Item>
-            </Tooltip>
-            <Tooltip text='Area'>
-              <ToggleButtonGroup.Item value='area' disabled={!canChart} aria-label='Switch to area chart view'>
-                <StackedAreaChartIcon />
-              </ToggleButtonGroup.Item>
-            </Tooltip>
-          </ToggleButtonGroup>
+            {state.records.length} {state.records.length === 1 ? 'record' : 'records'}
+          </Text>
+          {metadataText && (
+            <Text textStyle='small' style={{ color: SUBDUED_TEXT_COLOR }} className='execute-dql-metadata-text'>
+              {metadataText}
+            </Text>
+          )}
+          {metadata.warnings.length > 0 && (
+            <Flex flexDirection='row' gap={8} alignItems='center' className='execute-dql-warnings'>
+              {metadata.warnings.map((warning, i) => (
+                <MetadataIcon key={`${warning}-${i}`} icon={<WarningIcon />} tooltip={warning} warning />
+              ))}
+            </Flex>
+          )}
+          <Flex
+            flexDirection='row'
+            gap={4}
+            alignItems='center'
+            style={{ marginLeft: 'auto' }}
+            className='execute-dql-toolbar-actions'
+          >
+            <ToggleButtonGroup
+              value={toggleValue}
+              onChange={(val) => setToggleValue(val as CombinedChartVariantToggleValue)}
+            >
+              <Tooltip text='Table'>
+                <ToggleButtonGroup.Item value='table' aria-label='Switch to table view'>
+                  <ToggleButtonGroup.Prefix>
+                    <DataTableIcon />
+                  </ToggleButtonGroup.Prefix>
+                </ToggleButtonGroup.Item>
+              </Tooltip>
+              <Tooltip text='Line'>
+                <ToggleButtonGroup.Item value='line' disabled={!canChart} aria-label='Switch to line chart view'>
+                  <ToggleButtonGroup.Prefix>
+                    <LineChartIcon />
+                  </ToggleButtonGroup.Prefix>
+                </ToggleButtonGroup.Item>
+              </Tooltip>
+              <Tooltip text='Area'>
+                <ToggleButtonGroup.Item value='area' disabled={!canChart} aria-label='Switch to area chart view'>
+                  <ToggleButtonGroup.Prefix>
+                    <StackedAreaChartIcon />
+                  </ToggleButtonGroup.Prefix>
+                </ToggleButtonGroup.Item>
+              </Tooltip>
+            </ToggleButtonGroup>
 
-          <Flex flexDirection='row' gap={4} alignItems='center' className='execute-dql-primary-actions'>
             <Tooltip text='Open in Notebooks'>
               <Button
                 variant='default'
-                size='condensed'
                 onClick={handleOpenInNotebooks}
                 aria-label='Open query in Dynatrace Notebooks'
                 className='execute-dql-open-button'
@@ -411,11 +413,11 @@ export function ExecuteDqlApp() {
                 <Button.Prefix>
                   <DocumentStackIcon />
                 </Button.Prefix>
-                <span className='execute-dql-open-button-label'>Open in Notebooks</span>
+                <Button.Label className='execute-dql-open-button-label'>Open in Notebooks</Button.Label>
               </Button>
             </Tooltip>
             <Tooltip text='Refresh'>
-              <Button variant='default' size='condensed' onClick={handleRefresh} aria-label='Refresh query results'>
+              <Button variant='default' onClick={handleRefresh} aria-label='Refresh query results'>
                 <Button.Prefix>
                   <RefreshIcon />
                 </Button.Prefix>
@@ -423,25 +425,32 @@ export function ExecuteDqlApp() {
             </Tooltip>
           </Flex>
         </Flex>
-      </Flex>
 
-      {state.records.length === 0 ? (
-        <Flex flexDirection='column' alignItems='center' justifyContent='center' padding={32}>
-          <Text textStyle='base-emphasized'>No records returned</Text>
-          <Text textStyle='small' style={{ opacity: EMPTY_STATE_TEXT_OPACITY }}>
-            The query executed successfully but returned no data. Try adjusting your query or timeframe.
-          </Text>
-        </Flex>
-      ) : viewMode === 'table' ? (
-        <DataTable data={tableData} columns={tableColumns} sortable resizable fullWidth>
-          <DataTable.Pagination defaultPageSize={DEFAULT_PAGE_SIZE} />
-        </DataTable>
-      ) : (
-        <TimeseriesChart data={timeseriesData} variant={chartVariant}>
-          <TimeseriesChart.Legend />
-          <TimeseriesChart.YAxis label='Value' />
-        </TimeseriesChart>
-      )}
-    </Flex>
+        {state.records.length === 0 ? (
+          <Flex flexDirection='column' alignItems='center' justifyContent='center' padding={32}>
+            <Text textStyle='base-emphasized'>No records returned</Text>
+            <Text textStyle='small' style={{ opacity: EMPTY_STATE_TEXT_OPACITY }}>
+              The query executed successfully but returned no data. Try adjusting your query or timeframe.
+            </Text>
+          </Flex>
+        ) : viewMode === 'table' ? (
+          <DataTable
+            data={tableData}
+            columns={tableColumns}
+            sortable
+            resizable
+            fullWidth
+            variant={{ rowDensity: 'condensed' }}
+          >
+            <DataTable.Pagination defaultPageSize={DEFAULT_PAGE_SIZE} />
+          </DataTable>
+        ) : (
+          <TimeseriesChart data={timeseriesData} variant={chartVariant}>
+            <TimeseriesChart.Legend />
+            <TimeseriesChart.YAxis label='Value' />
+          </TimeseriesChart>
+        )}
+      </Flex>
+    </div>
   );
 }


### PR DESCRIPTION
- Wrap results in a surface div using dt-colors-background-surface-default, dt-colors-border-neutral-default, and dt-borders-radius-surface-default
- Replace opacity-based dimming with dt-colors-text-neutral-subdued for metadata text
- Apply dt-colors-text-neutral-default explicitly to record count label
- Simplify LoadingState to use ProgressCircle children instead of separate Text
- Refactor toolbar icons to use ToggleButtonGroup.Prefix
- Add condensed row density to DataTable
- Remove inline padding from toolbar and unused primary-actions wrapper