### PR TITLE
chore: prepare release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 
+## 1.8.2
+
 - Fixed a "Cannot find module 'open'" startup error that occurred when running extracted MCPB bundles.
-- Updated `undici` (6.21.0 → 8.1.0).
+- Updated `undici` (6.21.0 → 8.1.0), `@dynatrace/strato-components` (3.2.0 → 3.2.1), and `@dynatrace/strato-components-preview` (3.2.0 → 3.2.1).
 
 ## 1.8.1
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "mcpServers": {
     "dynatrace": {
       "command": "npx",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dynatrace-mcp-server",
   "display_name": "Dynatrace MCP Server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Dynatrace Intelligence",
   "long_description": "The Dynatrace MCP Server connects Claude to your Dynatrace observability platform, enabling real-time access to logs, metrics, problems, vulnerabilities, traces, and more — directly from your AI assistant. Supports DQL queries, Dynatrace Intelligence, workflow automation, and document management.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-automation": "5.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "mcpName": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
     "source": "github"
   },
-  "version": "1.8.1",
+  "version": "1.8.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
This release ships fixes for the problems with Claude Desktop reported in #479  and #478 