### PR TITLE
feat: add human approval gate to send_event tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1363,6 +1363,15 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
         destructiveHint: true,
       },
       async ({ eventType, title, entitySelector, properties, startTime, endTime }) => {
+        // Request human approval before sending the event
+        const approved = await requestHumanApproval(
+          `Send ${eventType} event: "${title}"${entitySelector ? ` targeting ${entitySelector}` : ''}`,
+        );
+
+        if (!approved) {
+          return 'Operation cancelled: Human approval was not granted for sending this event.';
+        }
+
         const dtClient = await createAuthenticatedHttpClient(scopesBase.concat('storage:events:write'));
 
         const result = await sendEvent(dtClient, {


### PR DESCRIPTION
## Description

`send_event` is the only write-capable tool without a `requestHumanApproval` call. This was introduced in #292 (Jan 2026) after the approval pattern was established in #169 (Sep 2025) for `send_slack_message`, `send_email`, `create_workflow_for_notification`, and `make_workflow_public`.

Events of type `CUSTOM_ALERT` trigger Davis Problem creation, which can cascade into alerting workflows and on-call notifications — making this a potentially destructive operation that should require user consent.

This change adds the same `requestHumanApproval` pattern used by the other write tools.

## Changes

- Added `requestHumanApproval()` call before `sendEvent()` execution
- Approval message includes the event type, title, and entity selector (if provided)
- Returns cancellation message if approval is denied

## Testing

Tested against a dev tenant (`*.dev.apps.dynatracelabs.com`):
- Verified `send_event` previously accepted `CUSTOM_ALERT` events without approval, triggering Davis Problem creation
- After fix, the approval prompt is shown before event ingestion
- All existing unit tests pass (`npm test`)

## Related

- #169 — Original PR that added human approval to other write tools
- #292 — PR that introduced `send_event` without the approval gate