### PR TITLE
fix: parse CLI metadata flags before env validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,28 @@ const allRequiredScopes = scopesBase.concat([
 ]);
 
 const main = async () => {
+  // Parse command line arguments before any environment validation so users can
+  // inspect help/version metadata without configuring Dynatrace credentials.
+  const program = new Command();
+
+  program
+    .name('dynatrace-mcp-server')
+    .description('Dynatrace Model Context Protocol (MCP) Server')
+    .version(getPackageJsonVersion(), '-v, --version')
+    .option('--http', 'enable HTTP server mode instead of stdio')
+    .option('--server', 'enable HTTP server mode (alias for --http)')
+    .option('-p, --port <number>', 'port for HTTP server', '3000')
+    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
+    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
+    .allowUnknownOption() // Claude Desktop / Electron UtilityProcess may inject extra arguments
+    .allowExcessArguments() // Avoid "too many arguments" when launched from .mcpb bundles
+    .parse();
+
+  const options = program.opts();
+  const httpMode = options.http || options.server;
+  const httpPort = parseInt(options.port, 10);
+  const host = options.host || '0.0.0.0';
+
   console.error(`Initializing Dynatrace MCP Server v${getPackageJsonVersion()}...`);
 
   // Configure proxy from environment variables early in the startup process
@@ -1603,26 +1625,6 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     return server;
   }; // end createConfiguredMcpServer
 
-  // Parse command line arguments using commander
-  const program = new Command();
-
-  program
-    .name('dynatrace-mcp-server')
-    .description('Dynatrace Model Context Protocol (MCP) Server')
-    .version(getPackageJsonVersion())
-    .option('--http', 'enable HTTP server mode instead of stdio')
-    .option('--server', 'enable HTTP server mode (alias for --http)')
-    .option('-p, --port <number>', 'port for HTTP server', '3000')
-    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
-    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
-    .allowUnknownOption() // Claude Desktop / Electron UtilityProcess may inject extra arguments
-    .allowExcessArguments() // Avoid "too many arguments" when launched from .mcpb bundles
-    .parse();
-
-  const options = program.opts();
-  const httpMode = options.http || options.server;
-  const httpPort = parseInt(options.port, 10);
-  const host = options.host || '0.0.0.0';
   oauthRedirectPort = options.oauthRedirectPort ? parseInt(options.oauthRedirectPort, 10) : undefined;
 
   // HTTP server mode (Stateless)


### PR DESCRIPTION
## Summary
- parse Commander arguments before Dynatrace environment validation
- keep `--help`, `--version`, and `-v` available without `DT_ENVIRONMENT` configured
- preserve normal server startup validation for actual launches

## Test Plan
- `npm run typecheck`
- `npm run build`
- `unset DT_ENVIRONMENT DT_PLATFORM_TOKEN OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET; node dist/index.js --help`
- `unset DT_ENVIRONMENT DT_PLATFORM_TOKEN OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET; node dist/index.js --version`
- `unset DT_ENVIRONMENT DT_PLATFORM_TOKEN OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET; node dist/index.js -v`
- `unset DT_ENVIRONMENT DT_PLATFORM_TOKEN OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET; node dist/index.js` (still exits with `DT_ENVIRONMENT` validation)

Fixes dynatrace-oss/dynatrace-mcp#523
