### PR TITLE
Fix CLI metadata flags before env validation

### DIFF
--- a/src/cli-info-flags.test.ts
+++ b/src/cli-info-flags.test.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+import { version } from '../package.json';
+
+function runCli(...args: string[]) {
+  const env = { ...process.env };
+  delete env.DT_ENVIRONMENT;
+  delete env.OAUTH_CLIENT_ID;
+  delete env.OAUTH_CLIENT_SECRET;
+  delete env.DT_PLATFORM_TOKEN;
+  delete env.NODE_OPTIONS;
+
+  return spawnSync(process.execPath, ['-r', 'ts-node/register', 'src/index.ts', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...env,
+      DT_MCP_DISABLE_TELEMETRY: 'true',
+    },
+  });
+}
+
+describe('CLI information flags', () => {
+  it('prints help without requiring Dynatrace environment variables', () => {
+    const result = runCli('--help');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('Dynatrace Model Context Protocol');
+    expect(result.stderr).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('prints short help without requiring Dynatrace environment variables', () => {
+    const result = runCli('-h');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('Dynatrace Model Context Protocol');
+    expect(result.stderr).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('prints version without requiring Dynatrace environment variables', () => {
+    const result = runCli('--version');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(version);
+    expect(result.stderr).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('prints short version without requiring Dynatrace environment variables', () => {
+    const result = runCli('-v');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(version);
+    expect(result.stderr).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('rejects unknown top-level flags before environment validation', () => {
+    const result = runCli('--definitely-not-a-real-flag');
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("error: unknown option '--definitely-not-a-real-flag'");
+    expect(result.stderr).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('keeps environment validation for server startup', () => {
+    const result = runCli();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('DT_ENVIRONMENT');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,24 @@ const allRequiredScopes = scopesBase.concat([
 ]);
 
 const main = async () => {
+  // Parse command line arguments before environment validation so metadata flags
+  // such as --help and --version work in a clean install.
+  const program = new Command();
+
+  program
+    .name('dynatrace-mcp-server')
+    .description('Dynatrace Model Context Protocol (MCP) Server')
+    .version(getPackageJsonVersion(), '-v, --version')
+    .option('--http', 'enable HTTP server mode instead of stdio')
+    .option('--server', 'enable HTTP server mode (alias for --http)')
+    .option('-p, --port <number>', 'port for HTTP server', '3000')
+    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
+    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
+    .allowExcessArguments() // Avoid "too many arguments" when launched from .mcpb bundles
+    .parse();
+
+  const options = program.opts();
+
   console.error(`Initializing Dynatrace MCP Server v${getPackageJsonVersion()}...`);
 
   // Configure proxy from environment variables early in the startup process
@@ -1603,23 +1621,6 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     return server;
   }; // end createConfiguredMcpServer
 
-  // Parse command line arguments using commander
-  const program = new Command();
-
-  program
-    .name('dynatrace-mcp-server')
-    .description('Dynatrace Model Context Protocol (MCP) Server')
-    .version(getPackageJsonVersion())
-    .option('--http', 'enable HTTP server mode instead of stdio')
-    .option('--server', 'enable HTTP server mode (alias for --http)')
-    .option('-p, --port <number>', 'port for HTTP server', '3000')
-    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
-    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
-    .allowUnknownOption() // Claude Desktop / Electron UtilityProcess may inject extra arguments
-    .allowExcessArguments() // Avoid "too many arguments" when launched from .mcpb bundles
-    .parse();
-
-  const options = program.opts();
   const httpMode = options.http || options.server;
   const httpPort = parseInt(options.port, 10);
   const host = options.host || '0.0.0.0';


### PR DESCRIPTION
## Summary

- handle `--help` / `-h` and `--version` / `-v` before Dynatrace environment validation
- reject unknown top-level flags before server startup with a concise Commander error
- add CLI regression tests that run with Dynatrace auth/env vars unset

Fixes dynatrace-oss/dynatrace-mcp#523.

## Validation

- Red test first: `npm test -- --selectProjects unit src/cli-info-flags.test.ts` failed before the implementation because help/version reached `DT_ENVIRONMENT` validation.
- `NODE_OPTIONS= npm test -- --runTestsByPath src/cli-info-flags.test.ts --cacheDirectory=/tmp/automoney-dynatrace-mcp-jest-cache` passed: 6/6.
- `NODE_OPTIONS= npm test -- --selectProjects unit --cacheDirectory=/tmp/automoney-dynatrace-mcp-jest-cache` passed: 170/170.
- `npm run typecheck` passed.
- `npm run lint` passed with existing warnings only, 0 errors.
- `npx prettier --check src/index.ts src/cli-info-flags.test.ts` passed.
- `git diff --check` passed.
- `npm run build` passed.

Dist smoke after build:

```text
help_exit=0
help_stdout_first=Usage: dynatrace-mcp-server [options]
short_help_exit=0
short_help_stdout_first=Usage: dynatrace-mcp-server [options]
version_exit=0
version_stdout=1.8.6
short_version_exit=0
short_version_stdout=1.8.6
invalid_exit=1
invalid_stderr=error: unknown option '--definitely-not-a-real-flag'
start_exit=1
start_stderr=Initializing Dynatrace MCP Server v1.8.6...
Please set DT_ENVIRONMENT environment variable to your Dynatrace Platform Environment
```
