### PR TITLE
fix: handle CLI metadata flags before env validation

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,46 @@
+import { createCliProgram } from './cli';
+
+describe('CLI metadata flags', () => {
+  const runProgram = (args: string[]) => {
+    const output: string[] = [];
+    const errors: string[] = [];
+    const program = createCliProgram('1.8.6');
+
+    program.exitOverride();
+    program.configureOutput({
+      writeOut: (value: string) => output.push(value),
+      writeErr: (value: string) => errors.push(value),
+    });
+
+    try {
+      program.parse(['node', 'dist/index.js', ...args]);
+      return { output: output.join(''), errors: errors.join(''), exitCode: 0 };
+    } catch (error: unknown) {
+      const commandError = error as { exitCode?: number; code?: string };
+
+      return {
+        output: output.join(''),
+        errors: errors.join(''),
+        exitCode: commandError.exitCode,
+        code: commandError.code,
+      };
+    }
+  };
+
+  it('prints help without starting environment validation', () => {
+    const result = runProgram(['--help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Dynatrace Model Context Protocol (MCP) Server');
+    expect(result.output).toContain('--http');
+    expect(result.errors).not.toContain('DT_ENVIRONMENT');
+  });
+
+  it('prints version without starting environment validation', () => {
+    const result = runProgram(['--version']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output.trim()).toBe('1.8.6');
+    expect(result.errors).not.toContain('DT_ENVIRONMENT');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,14 @@
+import { Command } from 'commander';
+
+export const createCliProgram = (version: string) =>
+  new Command()
+    .name('dynatrace-mcp-server')
+    .description('Dynatrace Model Context Protocol (MCP) Server')
+    .version(version)
+    .option('--http', 'enable HTTP server mode instead of stdio')
+    .option('--server', 'enable HTTP server mode (alias for --http)')
+    .option('-p, --port <number>', 'port for HTTP server', '3000')
+    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
+    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
+    .allowUnknownOption() // Claude Desktop / Electron UtilityProcess may inject extra arguments
+    .allowExcessArguments(); // Avoid "too many arguments" when launched from .mcpb bundles

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,11 +101,11 @@ const allRequiredScopes = scopesBase.concat([
 const main = async () => {
   // Parse command line arguments before startup validation so metadata flags
   // like --help and --version do not require Dynatrace environment variables.
-  const program = createCliProgram(getPackageJsonVersion()).parse();
+  const version = getPackageJsonVersion();
+  const program = createCliProgram(version).parse();
   const options = program.opts();
 
-  console.error(`Initializing Dynatrace MCP Server v${getPackageJsonVersion()}...`);
-
+  console.error(`Initializing Dynatrace MCP Server v${version}...`);
   // Configure proxy from environment variables early in the startup process
   configureProxyFromEnvironment();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ import { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { Command } from 'commander';
 import { z, ZodRawShape, ZodTypeAny } from 'zod';
 
+import { createCliProgram } from './cli';
 import { getPackageJsonVersion } from './utils/version';
 import { createDtHttpClient } from './authentication/dynatrace-clients';
 import { listVulnerabilities } from './capabilities/list-vulnerabilities';
@@ -99,6 +99,11 @@ const allRequiredScopes = scopesBase.concat([
 ]);
 
 const main = async () => {
+  // Parse command line arguments before startup validation so metadata flags
+  // like --help and --version do not require Dynatrace environment variables.
+  const program = createCliProgram(getPackageJsonVersion()).parse();
+  const options = program.opts();
+
   console.error(`Initializing Dynatrace MCP Server v${getPackageJsonVersion()}...`);
 
   // Configure proxy from environment variables early in the startup process
@@ -1603,23 +1608,6 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     return server;
   }; // end createConfiguredMcpServer
 
-  // Parse command line arguments using commander
-  const program = new Command();
-
-  program
-    .name('dynatrace-mcp-server')
-    .description('Dynatrace Model Context Protocol (MCP) Server')
-    .version(getPackageJsonVersion())
-    .option('--http', 'enable HTTP server mode instead of stdio')
-    .option('--server', 'enable HTTP server mode (alias for --http)')
-    .option('-p, --port <number>', 'port for HTTP server', '3000')
-    .option('-H, --host <host>', 'host for HTTP server', '127.0.0.1')
-    .option('--oauth-redirect-port <number>', 'fixed port for the OAuth redirect server')
-    .allowUnknownOption() // Claude Desktop / Electron UtilityProcess may inject extra arguments
-    .allowExcessArguments() // Avoid "too many arguments" when launched from .mcpb bundles
-    .parse();
-
-  const options = program.opts();
   const httpMode = options.http || options.server;
   const httpPort = parseInt(options.port, 10);
   const host = options.host || '0.0.0.0';


### PR DESCRIPTION
## Summary
- move CLI option parsing before Dynatrace environment validation
- extract the Commander setup into a testable helper
- add regression coverage for --help and --version without DT_ENVIRONMENT

Fixes #523.

## Verification
- npm.cmd test -- --selectProjects unit --runTestsByPath src/cli.test.ts
- npm.cmd run test:unit
- npm.cmd run typecheck
- npm.cmd run lint
- npx.cmd prettier --check src/cli.ts src/cli.test.ts src/index.ts
- npm.cmd run build:server
- Remove-Item Env:DT_ENVIRONMENT -ErrorAction SilentlyContinue; node dist/index.js --help; node dist/index.js --version
- git diff --check