### PR TITLE
fix: improve detection of internal environments using parsed hostnames

### DIFF
--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -50,8 +50,7 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
   // We only require DT_ENVIRONMENT to be set
 
   // For dev and hardening stages, set unlimited budget (-1) unless explicitly overridden
-  const hostname = parsedDtEnvironment.hostname;
-  if (hostname.endsWith('.apps.dynatracelabs.com') && !env.DT_GRAIL_QUERY_BUDGET_GB) {
+  if (parsedDtEnvironment.hostname.endsWith('.apps.dynatracelabs.com') && !env.DT_GRAIL_QUERY_BUDGET_GB) {
     grailBudgetGB = -1;
   }
 

--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -37,11 +37,24 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
     throw new Error('Please set DT_ENVIRONMENT environment variable to your Dynatrace Platform Environment');
   }
 
+  let parsedDtEnvironment: URL;
+  try {
+    parsedDtEnvironment = new URL(dtEnvironment);
+  } catch {
+    throw new Error(
+      'Please set DT_ENVIRONMENT to a valid Dynatrace Environment URL (e.g., https://<environment-id>.apps.dynatrace.com)',
+    );
+  }
+
   // Allow case where no auth credentials are provided - OAuth auth code flow will be inferred
   // We only require DT_ENVIRONMENT to be set
 
   // For dev and hardening stages, set unlimited budget (-1) unless explicitly overridden
-  if (dtEnvironment.includes('apps.dynatracelabs.com') && !env.DT_GRAIL_QUERY_BUDGET_GB) {
+  const hostname = parsedDtEnvironment.hostname;
+  if (
+    (hostname === 'apps.dynatracelabs.com' || hostname.endsWith('.apps.dynatracelabs.com')) &&
+    !env.DT_GRAIL_QUERY_BUDGET_GB
+  ) {
     grailBudgetGB = -1;
   }
 

--- a/src/getDynatraceEnv.ts
+++ b/src/getDynatraceEnv.ts
@@ -51,10 +51,7 @@ export function getDynatraceEnv(env: NodeJS.ProcessEnv = process.env): Dynatrace
 
   // For dev and hardening stages, set unlimited budget (-1) unless explicitly overridden
   const hostname = parsedDtEnvironment.hostname;
-  if (
-    (hostname === 'apps.dynatracelabs.com' || hostname.endsWith('.apps.dynatracelabs.com')) &&
-    !env.DT_GRAIL_QUERY_BUDGET_GB
-  ) {
+  if (hostname.endsWith('.apps.dynatracelabs.com') && !env.DT_GRAIL_QUERY_BUDGET_GB) {
     grailBudgetGB = -1;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dynatrace-oss/dynatrace-mcp/security/code-scanning/86](https://github.com/dynatrace-oss/dynatrace-mcp/security/code-scanning/86)

**Impact** 

Literally zero, as this is only a convenience feature for Dynatrace-internal (testing) environments, and has zero impact on any customer.

**Fix**

The best fix is to parse `DT_ENVIRONMENT` as a URL and perform host-based checks using `URL.hostname` (or equivalent), instead of checking `includes(...)` on the full URL string.

In `src/getDynatraceEnv.ts`, update the logic around line 44 so that:
- A parsed URL object is created once after confirming `dtEnvironment` is set.
- The “dev/hardening unlimited budget default” check uses the parsed hostname and matches:
  - subdomains ending in `.apps.dynatracelabs.com`.
- Keep existing behavior otherwise unchanged.

No new dependency is required; `URL` is built into Node/TypeScript runtime.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
