### PR TITLE
ci: scope workflows to least-privilege permissions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/dynatrace-oss/dynatrace-mcp/security/code-scanning/78](https://github.com/dynatrace-oss/dynatrace-mcp/security/code-scanning/78)

Add an explicit `permissions` block to `.github/workflows/container.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal least-privilege setting is:

- `contents: read`

This is sufficient for `actions/checkout` and does not change existing functional behavior of build/run steps. No imports, methods, or additional definitions are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
