### PR TITLE
fix: pin @modelcontextprotocol/sdk to exact version 1.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@dynatrace/strato-components": "3.6.0",
     "@dynatrace/strato-icons": "^2.1.0",
     "@modelcontextprotocol/ext-apps": "^1.0.1",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "1.27.1",
     "commander": "^14.0.0",
     "open": "^8.4.2",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- **What:** Removed the `^` caret prefix from `@modelcontextprotocol/sdk` in `package.json`, pinning it to the exact version `1.27.1`
- **Why:** The MCP SDK handles all incoming HTTP request parsing and authentication flows — it is security-critical infrastructure. With the `^` prefix, any malicious patch release published to npm would be picked up automatically on the next `npm install` without any code review (supply chain attack vector)
- **Exact version:** `1.27.1` — verified from the currently resolved entry in `package-lock.json`
- **Lockfile unchanged:** `package-lock.json` already resolves to `1.27.1` and is not modified by this PR; this change only affects future installs that re-resolve dependencies

## Test plan

- [x] `package-lock.json` is unchanged — the installed package version is identical before and after
- [x] TypeScript pre-existing error in `src/index.ts` (unrelated `@modelcontextprotocol/ext-apps` module resolution) is not introduced by this change
- [x] Verify `npm ci` in CI continues to pass (lockfile pin ensures deterministic install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)