### PR TITLE
fix: change default host binding to 127.0.0.1 to prevent unintended exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --port 3001
 
 # Run with custom host/IP (using short or long flag)
 npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 127.0.0.1 # recommended for local computers
-npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 0.0.0.0 # recommended for container
+npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 0.0.0.0 # required for container (binds all interfaces; omitting --host defaults to 127.0.0.1)
 npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http -H 192.168.0.1 # recommended when sharing connection over a local network
 
 # Static OAuth callback port (useful when the port must be exposed, e.g., when running the MCP in a container)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1527,7 +1527,7 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
 
   const httpMode = options.http || options.server;
   const httpPort = parseInt(options.port, 10);
-  const host = options.host || '0.0.0.0';
+  const host = options.host || '127.0.0.1';
   oauthRedirectPort = options.oauthRedirectPort ? parseInt(options.oauthRedirectPort, 10) : undefined;
 
   // HTTP server mode (Stateless)


### PR DESCRIPTION
## Summary

- **What changed:** `src/index.ts` line 1622 — the `options.host` fallback was changed from `'0.0.0.0'` to `'127.0.0.1'`. The `README.md` example comment for container usage was updated to clarify that `--host 0.0.0.0` must be explicitly passed.
- **Why:** A Docker deployment that does not pass `--host` would silently bind the MCP server to `0.0.0.0`, exposing an unauthenticated API endpoint to all container network interfaces. The CLI parser in `cli.ts` already declared `127.0.0.1` as the default for `--host`; the fallback in `index.ts` was inconsistent with that documented default and represented a security gap.
- **Migration:** Operators running the server in Docker (or any environment) who need the server reachable beyond localhost must now explicitly pass `--host 0.0.0.0` (or another external bind address). Deployments that already pass `--host` are unaffected.

## Test plan

- [ ] Run `node dist/index.js --http` and verify the server listens on `127.0.0.1:3000` (not `0.0.0.0:3000`)
- [ ] Run `node dist/index.js --http --host 0.0.0.0` and verify the server listens on `0.0.0.0:3000`
- [ ] Verify `npm run build` completes without new TypeScript errors (pre-existing module-resolution warning is unrelated to this change)
- [ ] Confirm existing MCP client configurations that pass `--host` explicitly are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)