### PR TITLE
feat: add /health endpoint to HTTP server mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1539,13 +1539,17 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     console.error();
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
       // Health check endpoint — unauthenticated, must not expose sensitive data
-      if (req.method === 'GET' && req.url === '/health') {
+      const reqPath = req.url ? new URL(req.url, 'http://localhost').pathname : '';
+      if (req.method === 'GET' && reqPath === '/health') {
         const health = {
           status: 'ok',
           uptime: process.uptime(),
           timestamp: new Date().toISOString(),
         };
-        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        });
         res.end(JSON.stringify(health));
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1538,6 +1538,18 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
     console.error('   See: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/');
     console.error();
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      // Health check endpoint — unauthenticated, must not expose sensitive data
+      if (req.method === 'GET' && req.url === '/health') {
+        const health = {
+          status: 'ok',
+          uptime: process.uptime(),
+          timestamp: new Date().toISOString(),
+        };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(health));
+        return;
+      }
+
       // Parse request body for POST requests
       let body: unknown;
       // Create a fresh MCP server instance per request to support concurrent


### PR DESCRIPTION
## What

Adds an unauthenticated `GET /health` endpoint to the HTTP server mode. The response is intentionally minimal:

```json
{
  "status": "ok",
  "uptime": 42.3,
  "timestamp": "2026-06-09T14:52:00.000Z"
}
```

## Why

We are planning to put all other endpoints behind Authentication (another PR), leaving no endpoint for container orchestrators (like Kubernetes) to check for liveness/readiness.

## Implementation details

- Placed at the very top of the HTTP request handler, **before** MCP transport creation and before any future auth middleware 
- Only active in `--http` / `--server` mode; STDIO mode is completely unaffected
- Uses `GET` so it cannot conflict with the MCP `POST` handler

## Security note

The response is intentionally minimal. It does **not** expose:
- Server version
- Dynatrace environment URL
- Whether an API token is configured
- Any other configuration signals

Only `status`, `uptime` (seconds since process start), and `timestamp` are returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)