### PR TITLE
fix: enable DNS rebinding protection in HTTP transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1584,9 +1584,7 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
       );
       const httpTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined, // No Session ID needed
-        // eslint-disable-next-line deprecation/deprecation -- built-in SDK option; external middleware is the long-term replacement
         enableDnsRebindingProtection: true,
-        // eslint-disable-next-line deprecation/deprecation -- built-in SDK option; external middleware is the long-term replacement
         allowedHosts,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1561,8 +1561,33 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
       // "Already connected to a transport" errors. See #345.
       const server = createConfiguredMcpServer();
       // Create a new Stateless HTTP Transport
+      // DNS rebinding protection: restrict accepted Host headers to the
+      // configured server address so that a malicious web page cannot reach
+      // this local server by rebinding a domain to 127.0.0.1.
+      // Note: enableDnsRebindingProtection only activates when allowedHosts
+      // and/or allowedOrigins are also supplied; the flag alone is a no-op.
+      // Both bare-host and host:port forms are allowed because HTTP/1.0
+      // clients may omit the port for well-known ports.
+      const allowedHosts = Array.from(
+        new Set([
+          host,
+          `${host}:${httpPort}`,
+          // Also allow the loopback aliases so tools that connect via
+          // "localhost" still work when the server binds to 127.0.0.1.
+          'localhost',
+          `localhost:${httpPort}`,
+          '127.0.0.1',
+          `127.0.0.1:${httpPort}`,
+          '[::1]',
+          `[::1]:${httpPort}`,
+        ]),
+      );
       const httpTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined, // No Session ID needed
+        // eslint-disable-next-line deprecation/deprecation -- built-in SDK option; external middleware is the long-term replacement
+        enableDnsRebindingProtection: true,
+        // eslint-disable-next-line deprecation/deprecation -- built-in SDK option; external middleware is the long-term replacement
+        allowedHosts,
       });
 
       res.on('close', () => {


### PR DESCRIPTION
## What

Enable `enableDnsRebindingProtection: true` and a dynamic `allowedHosts` list on the `StreamableHTTPServerTransport` constructor in the HTTP server mode.

## Why

Without this protection, a malicious web page visited by anyone on the same network can perform a DNS rebinding attack: the attacker's domain initially resolves to their server, but is re-bound to `127.0.0.1` after the browser caches the IP. Subsequent cross-origin POST requests from that page will then reach the local MCP server (e.g. `http://localhost:3000`) because nothing validates the `Host` header.

With `enableDnsRebindingProtection: true` and `allowedHosts` set, the SDK rejects any request whose `Host` header does not match the configured server address (returning HTTP 403).

## Implementation details

- `allowedHosts` is built dynamically from the configured `host` and `httpPort` so the protection works correctly regardless of which port/hostname the operator chose.
- Loopback aliases (`localhost`, `127.0.0.1`, `[::1]`) are always included so that MCP clients connecting via any of those aliases are not accidentally blocked when the server is bound to `127.0.0.1` (the CLI default).
- Both bare-host (`localhost`) and `host:port` (`localhost:3000`) forms are included because HTTP/1.0 clients may omit the port.
- The SDK marks these options as `@deprecated` in favour of external middleware; `eslint-disable` comments are included to suppress the deprecation warning at the call-site. Using the built-in option is appropriate here since the project does not yet have an express/middleware layer.

## SDK version

The options (`enableDnsRebindingProtection`, `allowedHosts`, `allowedOrigins`) are present in `@modelcontextprotocol/sdk` v1.27.1 (the version currently in use). They are deprecated in favour of external middleware but remain fully functional.

## Test plan

- [ ] Run `npm run build` — no new TypeScript errors (existing pre-existing `ext-apps` resolution error in worktree is unrelated)
- [ ] Start the server with `--http` and verify an HTTP client that sets `Host: localhost:3000` can connect normally
- [ ] Confirm a request with `Host: evil.example.com` is rejected with HTTP 403