### PR TITLE
chore(release): bump to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## 2.0.0
+
 - **Breaking**: Raised the minimum supported Node.js version from `22.10.0` to `24.0.0`.
-- Updated `@dynatrace-sdk/client-classic-environment-v2` (5.1.0 → 5.2.3), `@dynatrace-sdk/client-davis-analyzers` (1.9.8 → 1.10.0), `@dynatrace-sdk/client-document` (1.29.0 → 1.31.0), `@dynatrace-sdk/client-platform-management-service` (1.6.3 → 1.7.0), `@dynatrace-sdk/client-query` (1.18.1 → 1.25.0), `@dynatrace-sdk/shared-errors` (1.0.0 → 1.0.2), `@dynatrace/openkit-js` (4.1.0 → 4.2.0), `@dynatrace/strato-icons` (2.1.0 → 2.3.0), `@modelcontextprotocol/ext-apps` (1.0.1 → 1.2.2), `commander` (14.0.0 → 14.0.3), `zod` (4.1.0 → 4.1.13), and `zod-to-json-schema` (3.25.0 → 3.25.1).
-- **Removed** `create_workflow_for_notification` tool. The tool was not heavily used and `dtctl` provides more flexibility. If you relied on this tool, please create Dynatrace workflows manually via the Dynatrace UI, `dtctl`, or the Automations API.
-- **Removed** `make_workflow_public` tool. The tool was not heavily used and `dtctl` provides more flexibility. If you relied on this tool, please update workflow visibility manually via the Dynatrace UI, `dtctl`, or the Automations API.
+- **Breaking**: Removed`create_workflow_for_notification` tool. The tool was not heavily used and `dtctl` provides more flexibility. If you relied on this tool, please create Dynatrace workflows manually via the Dynatrace UI, `dtctl`, or the Automations API.
+- **Breaking**: Removed `make_workflow_public` tool. The tool was not heavily used and `dtctl` provides more flexibility. If you relied on this tool, please update workflow visibility manually via the Dynatrace UI, `dtctl`, or the Automations API.
+- **Deprecation**: Using `--http` mode without a bearer token is deprecated and will be removed in a future release.
+- Added `MCP_BEARER_TOKEN` environment variable to secure `--http` mode.
+- Several security improvements when running in `--http` mode
 - OAuth Authorization Code Flow tokens are now persisted to the OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service), so the browser authentication window only opens once per token lifetime instead of on every server restart.
+- Updated `@dynatrace-sdk/client-classic-environment-v2` (5.1.0 → 5.2.3), `@dynatrace-sdk/client-davis-analyzers` (1.9.8 → 1.10.0), `@dynatrace-sdk/client-document` (1.29.0 → 1.31.0), `@dynatrace-sdk/client-platform-management-service` (1.6.3 → 1.7.0), `@dynatrace-sdk/client-query` (1.18.1 → 1.25.0), `@dynatrace-sdk/shared-errors` (1.0.0 → 1.0.2), `@dynatrace/openkit-js` (4.1.0 → 4.2.0), `@dynatrace/strato-icons` (2.1.0 → 2.3.0), `@modelcontextprotocol/ext-apps` (1.0.1 → 1.2.2), `commander` (14.0.0 → 14.0.3), `zod` (4.1.0 → 4.1.13), and `zod-to-json-schema` (3.25.0 → 3.25.1).
 
 ## 1.8.7
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ For scenarios where you need to run the MCP server as an HTTP service instead of
 
 **Running as HTTP server:**
 
+Please secure your server with a bearer token:
+
+```bash
+export MCP_BEARER_TOKEN=<bearer-token>
+```
+
 ```bash
 # Get help and see all available options
 npx -y @dynatrace-oss/dynatrace-mcp-server@latest --help
@@ -296,7 +302,10 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --version
   "mcpServers": {
     "dynatrace-http": {
       "url": "http://localhost:3000",
-      "transport": "http"
+      "transport": "http",
+      "headers": {
+        "Authorization": "Bearer <bearer-token>"
+      }
     }
   }
 }
@@ -306,10 +315,10 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --version
 
 When running in HTTP mode you can protect the server with a bearer token:
 
-| Behavior                       | Detail                                                                                                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MCP_BEARER_TOKEN` **set**     | Every HTTP request must include an `Authorization: Bearer <token>` header. Requests without a valid token receive `401 Unauthorized`.                                     |
-| `MCP_BEARER_TOKEN` **not set** | The server starts with a warning printed to stderr and accepts all requests without authentication. **Not recommended for production or any network-exposed deployment.** |
+| Behavior                       | Detail                                                                                                                                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_BEARER_TOKEN` **set**     | Every HTTP request must include an `Authorization: Bearer <token>` header. Requests without a valid token receive `401 Unauthorized`.                                                    |
+| `MCP_BEARER_TOKEN` **not set** | **Deprecated** The server starts with a warning printed to stderr and accepts all requests without authentication. **Not recommended for production or any network-exposed deployment.** |
 
 **Generating a secure token:**
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-mcp-server",
-  "version": "1.8.7",
+  "version": "2.0.0",
   "mcpServers": {
     "dynatrace": {
       "command": "npx",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dynatrace-mcp-server",
   "display_name": "Dynatrace MCP Server",
-  "version": "1.8.7",
+  "version": "2.0.0",
   "description": "Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Dynatrace Intelligence",
   "long_description": "The Dynatrace MCP Server connects Claude to your Dynatrace observability platform, enabling real-time access to logs, metrics, problems, vulnerabilities, traces, and more — directly from your AI assistant. Supports DQL queries, Dynatrace Intelligence, workflow automation, and document management.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "1.8.7",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "1.8.7",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-classic-environment-v2": "5.2.3",
@@ -4255,9 +4255,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4275,9 +4272,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4295,9 +4289,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4315,9 +4306,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4335,9 +4323,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4355,9 +4340,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11313,9 +11295,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11337,9 +11316,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11361,9 +11337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11385,9 +11358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "1.8.7",
+  "version": "2.0.0",
   "mcpName": "io.github.dynatrace-oss/Dynatrace-mcp",
   "description": "Model Context Protocol (MCP) server for Dynatrace",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
     "source": "github"
   },
-  "version": "1.8.7",
+  "version": "2.0.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "1.8.7",
+      "version": "2.0.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
With this release, we are updating several dependencies and we are addressing GHSA-p7w7-4929-vpj5 as well as GHSA-xrmj-5g4g-8987