### PR TITLE
feat(http): enforce MCP_BEARER_TOKEN requirement + add startup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Breaking**: `MCP_BEARER_TOKEN` is now required when running in `--http` mode. The server will refuse to start if this environment variable is not set. This follows the deprecation notice introduced in `2.0.0`. Set `MCP_BEARER_TOKEN` to a secure random value before starting the server (e.g. `export MCP_BEARER_TOKEN=$(openssl rand -base64 32)`).
+
 ## 2.0.1
 
 - Fixed: Human approval elicitation now defaults to `true`, so users only need to press Accept instead of having to toggle the value first.

--- a/README.md
+++ b/README.md
@@ -313,12 +313,9 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --version
 
 #### Bearer Token Authentication (`MCP_BEARER_TOKEN`)
 
-When running in HTTP mode you can protect the server with a bearer token:
+`MCP_BEARER_TOKEN` is **required** when running in HTTP mode. The server will refuse to start if this variable is not set.
 
-| Behavior                       | Detail                                                                                                                                                                                   |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MCP_BEARER_TOKEN` **set**     | Every HTTP request must include an `Authorization: Bearer <token>` header. Requests without a valid token receive `401 Unauthorized`.                                                    |
-| `MCP_BEARER_TOKEN` **not set** | **Deprecated** The server starts with a warning printed to stderr and accepts all requests without authentication. **Not recommended for production or any network-exposed deployment.** |
+Every HTTP request must include an `Authorization: Bearer <token>` header. Requests without a valid token receive `401 Unauthorized`.
 
 **Generating a secure token:**
 

--- a/src/http-startup.test.ts
+++ b/src/http-startup.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..');
+const TSNODE = resolve(ROOT, 'node_modules', '.bin', 'ts-node');
+
+// Strips MCP_BEARER_TOKEN from the current env so the test isn't affected by
+// whatever the developer happens to have set locally.
+const { MCP_BEARER_TOKEN: _stripped, ...baseEnv } = process.env;
+const testEnv = {
+  ...baseEnv,
+  DT_ENVIRONMENT: 'https://abc12345.apps.dynatrace.com',
+  DT_MCP_DISABLE_TELEMETRY: 'true',
+};
+
+describe('HTTP mode startup', () => {
+  it('exits with code 1 when MCP_BEARER_TOKEN is not set', () => {
+    const result = spawnSync(TSNODE, ['src/index.ts', '--http'], {
+      env: testEnv,
+      cwd: ROOT,
+      timeout: 15000,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('MCP_BEARER_TOKEN is required');
+  }, 20000);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1541,8 +1541,10 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
 
     const bearerToken = process.env.MCP_BEARER_TOKEN;
     if (!bearerToken) {
-      console.error('⚠️  WARNING: MCP_BEARER_TOKEN is not set. The HTTP server is running without authentication.');
-      console.error('    Set MCP_BEARER_TOKEN to require a bearer token on all requests.');
+      console.error('❌ ERROR: MCP_BEARER_TOKEN is required when running in --http mode.');
+      console.error('   Set MCP_BEARER_TOKEN to a secure random value before starting the server:');
+      console.error('     export MCP_BEARER_TOKEN=$(openssl rand -base64 32)');
+      process.exit(1);
     }
 
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
@@ -1562,22 +1564,20 @@ You can now execute new Grail queries (DQL, etc.) again. If this happens more of
         return;
       }
 
-      // Bearer token authentication: only enforced when MCP_BEARER_TOKEN is set
-      if (bearerToken) {
-        if (!validateBearerToken(req.headers.authorization, bearerToken)) {
-          res.writeHead(401, {
-            'WWW-Authenticate': 'Bearer realm="dynatrace-mcp"',
-            'Content-Type': 'application/json',
-          });
-          res.end(
-            JSON.stringify({
-              jsonrpc: '2.0',
-              id: null,
-              error: { code: -32001, message: 'Unauthorized' },
-            }),
-          );
-          return;
-        }
+      // Bearer token authentication: always enforced in HTTP mode
+      if (!validateBearerToken(req.headers.authorization, bearerToken)) {
+        res.writeHead(401, {
+          'WWW-Authenticate': 'Bearer realm="dynatrace-mcp"',
+          'Content-Type': 'application/json',
+        });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32001, message: 'Unauthorized' },
+          }),
+        );
+        return;
       }
 
       // Parse request body for POST requests


### PR DESCRIPTION
## Summary

Builds on #550 (Copilot PR): enforces `MCP_BEARER_TOKEN` as a hard requirement when running in `--http` mode.

- Replaces the missing-token warning with `process.exit(1)` and a clear error message
- Removes the now-redundant `if (bearerToken)` guard around per-request validation
- Cleans up `README.md` to state the token is required
- Documents the breaking change in `CHANGELOG.md`
- **Adds a subprocess test** verifying the server exits with code 1 when `MCP_BEARER_TOKEN` is not set in HTTP mode (the gap in the original Copilot PR)

## Test plan

- [ ] `npm run test:unit` passes (all 210 tests + new `http-startup.test.ts`)
- [ ] Manual: start server with `--http` but without `MCP_BEARER_TOKEN` → exits with code 1 and prints the error message
- [ ] Manual: start server with `--http` and `MCP_BEARER_TOKEN` set → starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)