### PR TITLE
chore: deprecate repository, redirect to remote MCP and dtctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ## 2.1.2
 
-- This is the final release. The repository is deprecated — no further updates will be made.
-- Added a deprecation notice printed to stderr on server startup, redirecting users to actively maintained alternatives.
-- Updated marketplace descriptions (`manifest.json`, `server.json`, `package.json`) to reflect deprecation status.
-- For local development (VS Code, Cursor, Claude Code, IntelliJ, …), migrate to [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + [`dtctl`](https://github.com/dynatrace-oss/dtctl).
-- For agent-to-agent use cases (Atlassian Rovo, GitHub Coding Agent, …), use the [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/).
+- This is the final release. This repository is now deprecated — see [README](README.md) for migration options.
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.1.2
+
+- This is the final release. The repository is deprecated — no further updates will be made.
+- Added a deprecation notice printed to stderr on server startup, redirecting users to actively maintained alternatives.
+- Updated marketplace descriptions (`manifest.json`, `server.json`, `package.json`) to reflect deprecation status.
+- For local development (VS Code, Cursor, Claude Code, IntelliJ, …), migrate to [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + [`dtctl`](https://github.com/dynatrace-oss/dtctl).
+- For agent-to-agent use cases (Atlassian Rovo, GitHub Coding Agent, …), use the [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/).
+
 ## 2.1.1
 
 - Fixed a security vulnerability where DQL template parameters in several tools were not validated or escaped before being embedded into queries, potentially allowing DQL injection. Timeframe values are now validated against a strict duration format, additional filter strings are checked for pipeline-injection characters, and string values are properly escaped in DQL string literals. Affected tools: `find_entity_by_name`, `get_kubernetes_events`, `list_exceptions`, `list_problems`, and `list_vulnerabilities`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## ⚠️ DEPRECATED
 
-> **This repository is deprecated. Version 2.1.1 was the final release — no further updates will be made.**
+> **This repository is deprecated. Version 2.1.2 was the final release — no further updates will be made.**
 
 Please migrate to one of the actively maintained alternatives:
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@
   </a>
 </h4>
 
-## 🛠️ MAINTENANCE MODE
+## ⚠️ DEPRECATED
 
-Please note, that this repository is currently in [_Maintenance Mode_](https://github.com/dynatrace-oss/dynatrace-mcp/issues/496). We will continue fixing/patching issues when they come up.
+> **This repository is deprecated. Version 2.1.1 was the final release — no further updates will be made.**
 
-**Recommended Actions**
+Please migrate to one of the actively maintained alternatives:
 
-> 🚀 **Try [Dynatrace-for-Ai](https://github.com/Dynatrace/dynatrace-for-ai/) and [`dtctl`](https://github.com/dynatrace-oss/dtctl)** (recommended for local development use cases like VS Code, IntelliJ, Claude Code, Cursor and alike)
+| Use case | Recommended tool |
+| --- | --- |
+| **Local development** (VS Code, IntelliJ, Claude Code, Cursor, …) | [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + [`dtctl`](https://github.com/dynatrace-oss/dtctl) |
+| **Agent-to-agent / remote** (Atlassian Rovo, GitHub Coding Agent, …) | [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/) — no local setup required |
 
-> **Try out our new [Remote Dynatrace MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/)!** Now available - no local setup required, connect instantly to your Dynatrace environment from any MCP-compatible client. See our [migration guide](docs/remote-mcp-migration.md) for a comparison and step-by-step instructions. This setup is recommended when connecting another Agent (e.g., Atlassian Rovo, GitHub Coding Agent and alike) to Dynatrace.
+See the [migration guide](docs/remote-mcp-migration.md) for a step-by-step comparison and migration instructions.
 
 The local _Dynatrace MCP server_ allows AI Assistants to interact with the [Dynatrace](https://www.dynatrace.com/) observability platform,
 bringing real-time observability data directly into your development workflow.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 
 Please migrate to one of the actively maintained alternatives:
 
-| Use case | Recommended tool |
-| --- | --- |
-| **Local development** (VS Code, IntelliJ, Claude Code, Cursor, …) | [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + [`dtctl`](https://github.com/dynatrace-oss/dtctl) |
-| **Agent-to-agent / remote** (Atlassian Rovo, GitHub Coding Agent, …) | [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/) — no local setup required |
+| Use case                                                             | Recommended tool                                                                                                       |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Local development** (VS Code, IntelliJ, Claude Code, Cursor, …)    | [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + [`dtctl`](https://github.com/dynatrace-oss/dtctl) |
+| **Agent-to-agent / remote** (Atlassian Rovo, GitHub Coding Agent, …) | [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/) — no local setup required    |
 
 See the [migration guide](docs/remote-mcp-migration.md) for a step-by-step comparison and migration instructions.
 

--- a/docs/remote-mcp-migration.md
+++ b/docs/remote-mcp-migration.md
@@ -1,5 +1,7 @@
 # Migrating from Local to Remote Dynatrace MCP Server
 
+> **⚠️ The local Dynatrace MCP Server is deprecated as of version 2.1.1. This guide covers how to migrate away from it.**
+
 Dynatrace now offers an official **Remote MCP Server** that runs directly in your Dynatrace SaaS environment — no local setup, no Node.js, and no `npx` required.
 
 👉 **[Dynatrace Remote MCP Server Documentation](https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-mcp)**

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-mcp-server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "mcpServers": {
     "dynatrace": {
       "command": "npx",

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.3",
   "name": "dynatrace-mcp-server",
   "display_name": "Dynatrace MCP Server",
-  "version": "2.1.1",
-  "description": "Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Dynatrace Intelligence",
-  "long_description": "The Dynatrace MCP Server connects Claude to your Dynatrace observability platform, enabling real-time access to logs, metrics, problems, vulnerabilities, traces, and more — directly from your AI assistant. Supports DQL queries, Dynatrace Intelligence, workflow automation, and document management.",
+  "version": "2.1.2",
+  "description": "[DEPRECATED] Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Dynatrace Intelligence",
+  "long_description": "⚠️ This package is deprecated (final release: v2.1.2). For local development (VS Code, Cursor, Claude Code, IntelliJ, …), migrate to Dynatrace-for-AI + dtctl: https://github.com/Dynatrace/dynatrace-for-ai/. For agent-to-agent use cases (Atlassian Rovo, GitHub Coding Agent, …), use the Dynatrace Remote MCP Server: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/",
   "author": {
     "name": "Dynatrace OSS",
     "url": "https://github.com/dynatrace-oss"

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Dynatrace MCP Server",
   "version": "2.1.2",
   "description": "[DEPRECATED] Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Dynatrace Intelligence",
-  "long_description": "⚠️ This package is deprecated (final release: v2.1.2). For local development (VS Code, Cursor, Claude Code, IntelliJ, …), migrate to Dynatrace-for-AI + dtctl: https://github.com/Dynatrace/dynatrace-for-ai/. For agent-to-agent use cases (Atlassian Rovo, GitHub Coding Agent, …), use the Dynatrace Remote MCP Server: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/",
+  "long_description": "⚠️ This package is deprecated and no longer maintained. For local development (VS Code, Cursor, Claude Code, IntelliJ, …), migrate to Dynatrace-for-AI + dtctl: https://github.com/Dynatrace/dynatrace-for-ai/. For agent-to-agent use cases (Atlassian Rovo, GitHub Coding Agent, …), use the Dynatrace Remote MCP Server: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/",
   "author": {
     "name": "Dynatrace OSS",
     "url": "https://github.com/dynatrace-oss"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@dynatrace-sdk/client-classic-environment-v2": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dynatrace-oss/dynatrace-mcp-server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "mcpName": "io.github.dynatrace-oss/Dynatrace-mcp",
-  "description": "Model Context Protocol (MCP) server for Dynatrace",
+  "description": "[DEPRECATED] Model Context Protocol (MCP) server for Dynatrace. Migrate to dynatrace-for-ai + dtctl or the Dynatrace Remote MCP Server.",
   "keywords": [
     "Dynatrace",
     "mcp",

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dynatrace-oss/Dynatrace-mcp",
-  "description": "Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Davis AI",
+  "description": "[DEPRECATED] Access Dynatrace observability data: logs, metrics, problems, vulnerabilities via DQL and Davis AI. Migrate to dynatrace-for-ai + dtctl or the Dynatrace Remote MCP Server.",
   "repository": {
     "url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@dynatrace-oss/dynatrace-mcp-server",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,24 @@ const main = async () => {
   const program = createCliProgram(version).parse();
   const options = program.opts();
 
+  console.error(
+    [
+      '',
+      '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+      '  DEPRECATION NOTICE',
+      '  This local Dynatrace MCP Server is deprecated. Last release: v2.1.1.',
+      '  No further updates will be made.',
+      '',
+      '  Please migrate to:',
+      '  - Local dev (VS Code, IntelliJ, Claude Code, Cursor, ...):',
+      '    https://github.com/Dynatrace/dynatrace-for-ai/ + dtctl',
+      '    https://github.com/dynatrace-oss/dtctl',
+      '  - Remote MCP Server (no local setup required):',
+      '    https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/',
+      '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+      '',
+    ].join('\n'),
+  );
   console.error(`Initializing Dynatrace MCP Server v${version}...`);
   // Configure proxy from environment variables early in the startup process
   configureProxyFromEnvironment();

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ const main = async () => {
       '',
       '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
       '  DEPRECATION NOTICE',
-      '  This local Dynatrace MCP Server is deprecated. Last release: v2.1.1.',
+      '  This local Dynatrace MCP Server is deprecated. Last release: v2.1.2.',
       '  No further updates will be made.',
       '',
       '  Please migrate to:',


### PR DESCRIPTION
## Summary

- Replaces the "Maintenance Mode" notice in `README.md` with a clear **DEPRECATED** banner (last release: v2.1.1), including a use-case table pointing users to [Dynatrace-for-AI](https://github.com/Dynatrace/dynatrace-for-ai/) + `dtctl` (local dev) and the [Dynatrace Remote MCP Server](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/) (agent-to-agent)
- Adds a deprecation note at the top of `docs/remote-mcp-migration.md` for users landing there directly
- Adds a runtime deprecation banner printed to stderr on server startup, visible in MCP client logs

## Test plan

- [ ] README renders correctly on GitHub (table, blockquote, links)
- [ ] Runtime banner appears in stderr when starting the server locally (`npx . 2>&1 | head -20`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)